### PR TITLE
[feat] post/lost 분리

### DIFF
--- a/src/main/java/muit/backend/controller/LostController.java
+++ b/src/main/java/muit/backend/controller/LostController.java
@@ -1,0 +1,56 @@
+package muit.backend.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.ApiResponse;
+import muit.backend.domain.enums.PostType;
+import muit.backend.dto.postDTO.LostRequestDTO;
+import muit.backend.dto.postDTO.LostResponseDTO;
+import muit.backend.dto.postDTO.PostRequestDTO;
+import muit.backend.dto.postDTO.PostResponseDTO;
+import muit.backend.service.LostService;
+import muit.backend.service.PostService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/losts")
+public class LostController {
+
+    private final LostService lostService;
+
+    @PostMapping("/")
+    @Operation(summary = "분실물글 생성 API", description = "분실물 게시판에 글을 작성하는 API 입니다.")
+    @Parameters({
+            @Parameter(name = "postType", description = "게시판 종류, LOST, FOUND")
+    })
+    public ApiResponse<LostResponseDTO.CreateLostResponseDTO> addPost(@RequestParam("postType") PostType postType, @RequestBody LostRequestDTO lostRequestDTO) {
+        return ApiResponse.onSuccess(lostService.createLostPost(postType, lostRequestDTO));
+    }
+
+    @GetMapping("/")
+    @Operation(summary = "게시판 게시글 리스트 조회 API", description = "특정 게시판의 게시글 목록을 조회하는 API 이며 query string 으로 postType과 page를 받음")
+    @Parameters({
+            @Parameter(name = "postType", description = "게시판 종류, LOST, FOUND, REVIEW, BLIND, HOT 중에 선택"),
+            @Parameter( name = "page", description = "페이지를 정수로 입력")
+    })
+    public ApiResponse<LostResponseDTO.LostResultListDTO> getPostList(@RequestParam("postType") PostType postType, @RequestParam(defaultValue = "0", name = "page") Integer page) {
+        return ApiResponse.onSuccess(lostService.getLostPostList(postType, page));
+    }
+
+    @GetMapping("/{postId}")
+    @Operation(summary = "게시글 단건 조회 API", description = "특정 게시글을 조회하는 API 입니다.")
+    public ApiResponse<LostResponseDTO.LostResultDTO> getPost(@PathVariable("postId") Long postId) {
+        return ApiResponse.onSuccess(lostService.getLostPost(postId));
+    }
+
+
+    @PatchMapping("/{postId}")
+    @Operation(summary = "게시글 수정 API", description = "특정 게시글을 수정하는 API 입니다.")
+    public ApiResponse<LostResponseDTO.CreateLostResponseDTO> editPost(@PathVariable("postId") Long postId, @RequestBody LostRequestDTO lostRequestDTO) {
+        return ApiResponse.onSuccess(lostService.editLostPost(postId, lostRequestDTO));
+    }
+
+}

--- a/src/main/java/muit/backend/converter/LostConverter.java
+++ b/src/main/java/muit/backend/converter/LostConverter.java
@@ -5,6 +5,7 @@ import muit.backend.domain.entity.member.Post;
 import muit.backend.domain.entity.musical.Musical;
 import muit.backend.domain.enums.PostType;
 import muit.backend.dto.postDTO.LostRequestDTO;
+import muit.backend.dto.postDTO.LostResponseDTO;
 import muit.backend.dto.postDTO.PostRequestDTO;
 import muit.backend.dto.postDTO.PostResponseDTO;
 import org.springframework.data.domain.Page;
@@ -12,37 +13,36 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class PostConverter {
-    //RequestDTO : POST 메서드에서 받아오는 dto
-    //ResultDTO : GET 메서드에서 리턴하는 dto, ResultListDTO : List<ResultDTO>
-    //ResponseDTO : GET 이외의 메서드에서 리턴하는 dto
+public class LostConverter {
 
     // requestDTO -> Entity
     // 게시글 생성
-    public static Post toPost(Member member, Musical musical, PostType postType, PostRequestDTO requestDTO) {
+    public static Post toPost(Member member, PostType postType, LostRequestDTO requestDTO) {
         return Post.builder()
                 .postType(postType)
                 .member(member)
-                .musical(musical)
+                .musicalName(requestDTO.getMusicalName())
                 .title(requestDTO.getTitle())
                 .content(requestDTO.getContent())
                 .location(requestDTO.getLocation())
-                .rating(requestDTO.getRating())
+                .lostItem(requestDTO.getLostItem())
+                .lostDate(requestDTO.getLostDate())
                 .build();
     }
 
     // Entity -> ResultDTO
     // 게시글 조회 - 단건
-    public static PostResponseDTO.PostResultDTO toPostResultDTO(Post post) {
-        return PostResponseDTO.PostResultDTO.builder()
+    public static LostResponseDTO.LostResultDTO toLostResultDTO(Post post) {
+        return LostResponseDTO.LostResultDTO.builder()
                 .id(post.getId())
                 .postType(post.getPostType())
                 .memberId(post.getMember().getId())
-                .musicalId(post.getMusical().getId())
+                .musicalName(post.getMusicalName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .location(post.getLocation())
-                .rating(post.getRating())
+                .lostItem(post.getLostItem())
+                .lostDate(post.getLostDate())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
@@ -50,13 +50,13 @@ public class PostConverter {
 
     // List<Entity> -> ResultListDTO
     //게시판 조회 - 리스트
-    public static PostResponseDTO.PostResultListDTO toPostResultListDTO(Page<Post> postPage) {
-        List<PostResponseDTO.PostResultDTO> postResultListDTO = postPage.stream()
-                .map(PostConverter::toPostResultDTO).collect(Collectors.toList());
+    public static LostResponseDTO.LostResultListDTO toLostResultListDTO(Page<Post> postPage) {
+        List<LostResponseDTO.LostResultDTO> lostResultListDTO = postPage.stream()
+                .map(LostConverter::toLostResultDTO).collect(Collectors.toList());
 
-        return PostResponseDTO.PostResultListDTO.builder()
-                .postResultListDTO(postResultListDTO)
-                .listSize(postResultListDTO.size())
+        return LostResponseDTO.LostResultListDTO.builder()
+                .postResultListDTO(lostResultListDTO)
+                .listSize(lostResultListDTO.size())
                 .isFirst(postPage.isFirst())
                 .isLast(postPage.isLast())
                 .totalPage(postPage.getTotalPages())
@@ -66,17 +66,18 @@ public class PostConverter {
 
     // Entity -> ResponseDTO
     // 게시글 생성 후 Response
-    public static PostResponseDTO.CreatePostResponseDTO toCreatePostResponseDTO(String message, Post post) {
-        return PostResponseDTO.CreatePostResponseDTO.builder()
+    public static LostResponseDTO.CreateLostResponseDTO toCreateLostResponseDTO(String message, Post post) {
+        return LostResponseDTO.CreateLostResponseDTO.builder()
                 .message(message)
                 .id(post.getId())
                 .postType(post.getPostType())
                 .memberId(post.getMember().getId())
-                .musicalId(post.getMusical().getId())
+                .musicalName(post.getMusicalName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .location(post.getLocation())
-                .rating(post.getRating())
+                .lostItem(post.getLostItem())
+                .lostDate(post.getLostDate())
                 .createdAt(post.getCreatedAt())
                 .build();
     }

--- a/src/main/java/muit/backend/converter/PostConverter.java
+++ b/src/main/java/muit/backend/converter/PostConverter.java
@@ -26,6 +26,9 @@ public class PostConverter {
                 .title(requestDTO.getTitle())
                 .content(requestDTO.getContent())
                 .location(requestDTO.getLocation())
+                .rating(requestDTO.getRating())
+                .lostItem(requestDTO.getLostItem())
+                .lostDate(requestDTO.getLostDate())
                 .build();
     }
 
@@ -41,6 +44,11 @@ public class PostConverter {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .location(post.getLocation())
+                .rating(post.getRating())
+                .lostItem(post.getLostItem())
+                .lostDate(post.getLostDate())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 
@@ -73,6 +81,11 @@ public class PostConverter {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .location(post.getLocation())
+                .rating(post.getRating())
+                .lostItem(post.getLostItem())
+                .lostDate(post.getLostDate())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/muit/backend/domain/entity/member/Post.java
+++ b/src/main/java/muit/backend/domain/entity/member/Post.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import muit.backend.domain.common.BaseEntity;
 import muit.backend.domain.entity.musical.Musical;
 import muit.backend.domain.enums.PostType;
+import muit.backend.dto.postDTO.LostRequestDTO;
 import muit.backend.dto.postDTO.PostRequestDTO;
 import org.hibernate.annotations.DynamicUpdate;
 
@@ -75,10 +76,17 @@ public class Post extends BaseEntity {
         if(postRequestDTO.getContent()!=null){this.content = postRequestDTO.getContent();}
         if(postRequestDTO.getLocation()!=null){this.location = postRequestDTO.getLocation();}
         if(postRequestDTO.getRating()!=null){this.rating = postRequestDTO.getRating();}
-        if(postRequestDTO.getLostItem()!=null){this.lostItem = postRequestDTO.getLostItem();}
-        if(postRequestDTO.getLostDate()!=null){this.lostDate = postRequestDTO.getLostDate();}
-        if(postRequestDTO.getMusicalName()!=null){this.musicalName = postRequestDTO.getMusicalName();}
         return this;
 
+    }
+
+    public Post changeLost(LostRequestDTO lostRequestDTO){
+        if(lostRequestDTO.getTitle()!=null){this.title = lostRequestDTO.getTitle();}
+        if(lostRequestDTO.getContent()!=null){this.content = lostRequestDTO.getContent();}
+        if(lostRequestDTO.getLocation()!=null){this.location = lostRequestDTO.getLocation();}
+        if(lostRequestDTO.getLostItem()!=null){this.lostItem = lostRequestDTO.getLostItem();}
+        if(lostRequestDTO.getLostDate()!=null){this.lostDate = lostRequestDTO.getLostDate();}
+        if(lostRequestDTO.getMusicalName()!=null){this.musicalName = lostRequestDTO.getMusicalName();}
+        return this;
     }
 }

--- a/src/main/java/muit/backend/domain/entity/member/Post.java
+++ b/src/main/java/muit/backend/domain/entity/member/Post.java
@@ -9,7 +9,9 @@ import muit.backend.domain.common.BaseEntity;
 import muit.backend.domain.entity.musical.Musical;
 import muit.backend.domain.enums.PostType;
 import muit.backend.dto.postDTO.PostRequestDTO;
+import org.hibernate.annotations.DynamicUpdate;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +20,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@DynamicUpdate
 public class Post extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +36,14 @@ public class Post extends BaseEntity {
     private String location;
 
     private Integer commentCount;
+
+    private Integer rating;
+
+    private LocalDateTime lostDate;
+
+    private String lostItem;
+
+    private String musicalName;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> commentList = new ArrayList<>();
@@ -60,14 +71,14 @@ public class Post extends BaseEntity {
     }
 
     public Post changePost(PostRequestDTO postRequestDTO) {
-        return builder()
-                .id(this.id)
-                .member(this.member)
-                .musical(this.musical)
-                .postType(postRequestDTO.getPostType())
-                .title(postRequestDTO.getTitle())
-                .content(postRequestDTO.getContent())
-                .location(postRequestDTO.getLocation())
-                .build();
+        if(postRequestDTO.getTitle()!=null){this.title = postRequestDTO.getTitle();}
+        if(postRequestDTO.getContent()!=null){this.content = postRequestDTO.getContent();}
+        if(postRequestDTO.getLocation()!=null){this.location = postRequestDTO.getLocation();}
+        if(postRequestDTO.getRating()!=null){this.rating = postRequestDTO.getRating();}
+        if(postRequestDTO.getLostItem()!=null){this.lostItem = postRequestDTO.getLostItem();}
+        if(postRequestDTO.getLostDate()!=null){this.lostDate = postRequestDTO.getLostDate();}
+        if(postRequestDTO.getMusicalName()!=null){this.musicalName = postRequestDTO.getMusicalName();}
+        return this;
+
     }
 }

--- a/src/main/java/muit/backend/dto/postDTO/LostRequestDTO.java
+++ b/src/main/java/muit/backend/dto/postDTO/LostRequestDTO.java
@@ -1,0 +1,26 @@
+package muit.backend.dto.postDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LostRequestDTO {
+
+
+        private Long memberId;
+        private String musicalName;
+        private String title;
+        private String content;
+        private String location;
+        private String lostItem;
+        private LocalDateTime lostDate;
+
+
+}

--- a/src/main/java/muit/backend/dto/postDTO/LostResponseDTO.java
+++ b/src/main/java/muit/backend/dto/postDTO/LostResponseDTO.java
@@ -1,5 +1,6 @@
 package muit.backend.dto.postDTO;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,20 +11,21 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 
-public class PostResponseDTO {
+public class LostResponseDTO {
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PostResultDTO{
+    public static class LostResultDTO{
         private Long id;
         private PostType postType;
         private Long memberId;
-        private Long musicalId;
+        private String musicalName;
         private String title;
         private String content;
         private String location;
-        private Integer rating;
+        private LocalDateTime lostDate;
+        private String lostItem;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }
@@ -32,8 +34,8 @@ public class PostResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PostResultListDTO{
-        private List<PostResponseDTO.PostResultDTO> postResultListDTO;
+    public static class LostResultListDTO{
+        private List<LostResponseDTO.LostResultDTO> postResultListDTO;
         private Integer listSize;
         private Integer totalPage;
         private Long totalElements;
@@ -45,16 +47,17 @@ public class PostResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreatePostResponseDTO {
+    public static class CreateLostResponseDTO {
         private String message;
         private Long id;
         private PostType postType;
         private Long memberId;
-        private Long musicalId;
+        private String musicalName;
         private String title;
         private String content;
         private String location;
-        private Integer rating;
+        private LocalDateTime lostDate;
+        private String lostItem;
         private LocalDateTime createdAt;
 
     }

--- a/src/main/java/muit/backend/dto/postDTO/PostRequestDTO.java
+++ b/src/main/java/muit/backend/dto/postDTO/PostRequestDTO.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muit.backend.domain.enums.PostType;
 
+import java.time.LocalDateTime;
+
 @Builder
 @Getter
 @NoArgsConstructor
@@ -17,4 +19,8 @@ public class PostRequestDTO {
     private String title;
     private String content;
     private String location;
+    private Integer rating;
+    private LocalDateTime lostDate;
+    private String lostItem;
+    private String musicalName;
 }

--- a/src/main/java/muit/backend/dto/postDTO/PostRequestDTO.java
+++ b/src/main/java/muit/backend/dto/postDTO/PostRequestDTO.java
@@ -13,14 +13,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostRequestDTO {
-    private PostType postType;
     private Long memberId;
     private Long musicalId;
     private String title;
     private String content;
     private String location;
     private Integer rating;
-    private LocalDateTime lostDate;
-    private String lostItem;
-    private String musicalName;
 }

--- a/src/main/java/muit/backend/dto/postDTO/PostResponseDTO.java
+++ b/src/main/java/muit/backend/dto/postDTO/PostResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muit.backend.domain.enums.PostType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -23,6 +24,11 @@ public class PostResponseDTO {
         private String title;
         private String content;
         private String location;
+        private Integer rating;
+        private LocalDateTime lostDate;
+        private String lostItem;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
 
     @Builder
@@ -52,6 +58,11 @@ public class PostResponseDTO {
         private String title;
         private String content;
         private String location;
+        private Integer rating;
+        private LocalDateTime lostDate;
+        private String lostItem;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
 
     }
 

--- a/src/main/java/muit/backend/service/LostService.java
+++ b/src/main/java/muit/backend/service/LostService.java
@@ -1,0 +1,24 @@
+package muit.backend.service;
+
+import muit.backend.domain.enums.PostType;
+import muit.backend.dto.postDTO.LostRequestDTO;
+import muit.backend.dto.postDTO.LostResponseDTO;
+import muit.backend.dto.postDTO.PostRequestDTO;
+import muit.backend.dto.postDTO.PostResponseDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface LostService {
+
+    //특정 게시글 조회
+    public LostResponseDTO.LostResultDTO getLostPost(Long PostId);
+
+    //게시판 조회
+    public LostResponseDTO.LostResultListDTO getLostPostList(PostType postType, Integer page);
+
+    //게시글 생성
+    public LostResponseDTO.CreateLostResponseDTO createLostPost(PostType postType, LostRequestDTO lostRequestDTO);
+
+    //게시글 수정
+    LostResponseDTO.CreateLostResponseDTO editLostPost(Long postId, LostRequestDTO lostRequestDTO);
+}

--- a/src/main/java/muit/backend/service/LostServiceImpl.java
+++ b/src/main/java/muit/backend/service/LostServiceImpl.java
@@ -1,0 +1,80 @@
+package muit.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import muit.backend.converter.LostConverter;
+import muit.backend.converter.PostConverter;
+import muit.backend.domain.entity.member.Member;
+import muit.backend.domain.entity.member.Post;
+import muit.backend.domain.entity.musical.Musical;
+import muit.backend.domain.enums.PostType;
+import muit.backend.dto.postDTO.LostRequestDTO;
+import muit.backend.dto.postDTO.LostResponseDTO;
+import muit.backend.dto.postDTO.PostRequestDTO;
+import muit.backend.dto.postDTO.PostResponseDTO;
+import muit.backend.repository.MemberRepository;
+import muit.backend.repository.MusicalRepository;
+import muit.backend.repository.PostRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LostServiceImpl implements LostService {
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+    private final MusicalRepository musicalRepository;
+    //게시판 조회
+    @Override
+    public LostResponseDTO.LostResultListDTO getLostPostList(PostType postType, Integer page){
+        Page<Post> postPage = postRepository.findAllByPostType(postType, PageRequest.of(page, 10));
+        return LostConverter.toLostResultListDTO(postPage);
+    }
+
+    //특정 게시판 특정 게시글 단건 조회
+    @Override
+    public LostResponseDTO.LostResultDTO getLostPost(Long id) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Post not found"));
+
+        return LostConverter.toLostResultDTO(post);
+    }
+
+    //게시글 작성
+    @Override
+    @Transactional
+    public LostResponseDTO.CreateLostResponseDTO createLostPost(PostType postType, LostRequestDTO requestDTO) {
+
+        Member member = memberRepository.findById(requestDTO.getMemberId())
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+
+        // DTO -> Entity 변환
+        Post post = LostConverter.toPost(member, postType, requestDTO);
+
+        // 엔티티 저장
+        postRepository.save(post);
+
+        // Entity -> ResponseDTO 변환
+        String message = "등록 완료";
+        return LostConverter.toCreateLostResponseDTO(message, post);
+    }
+
+    @Override
+    @Transactional
+    public LostResponseDTO.CreateLostResponseDTO editLostPost(Long postId, LostRequestDTO lostRequestDTO) {
+        //post 유효성 검사
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("Post not found"));
+
+        //나머지 필드 수정
+        Post changedPost = post.changeLost(lostRequestDTO);
+
+        postRepository.save(changedPost);
+
+        String message = "수정 완료";
+        return LostConverter.toCreateLostResponseDTO(message, changedPost);
+    }
+}

--- a/src/main/java/muit/backend/service/PostServiceImpl.java
+++ b/src/main/java/muit/backend/service/PostServiceImpl.java
@@ -42,7 +42,6 @@ public class PostServiceImpl implements PostService {
                 .postType(post.getPostType())
                 .memberId(post.getMember().getId())
                 .musicalId(post.getMusical().getId())
-                .musicalName(post.getMusical().getName())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .location(post.getLocation())

--- a/src/main/java/muit/backend/service/PostServiceImpl.java
+++ b/src/main/java/muit/backend/service/PostServiceImpl.java
@@ -97,11 +97,12 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("Post not found"));
         //musical 유효성 검사
-        Long musicalId = requestDTO.getMusicalId();
-        Musical musical = musicalRepository.findById(musicalId)
-                .orElseThrow(() -> new RuntimeException("Musical not found"));
-        //musical 먼저 수정
-        post.changeMusical(musical);
+        if(requestDTO.getMusicalId()!=null){Long musicalId = requestDTO.getMusicalId();
+            Musical musical = musicalRepository.findById(musicalId)
+                    .orElseThrow(() -> new RuntimeException("Musical not found"));
+            //musical 먼저 수정
+            post.changeMusical(musical);}
+
         //나머지 필드 수정
         Post changedPost = post.changePost(requestDTO);
 


### PR DESCRIPTION
## 🔎 작업 내용

- post 테이블 수정사항 반영(lostItem 등 column 추가)
- 분실물 관련 로직(dto, controller, service, converter) 생성, post 관련 모든 파일에서 lost 관련 필드는 삭제했습니다.
- patch 로직 오류 수정 : 수정할 필드만 보냈을 때 나머지 값이 null 값으로 업데이트 되는 상태 -> 수정할 필드만 업데이트 되도록 변경

  <br/>

## 🔧 Todo

- 게시글 삭제를 lost와 post가 공유하는 API로 구현하는 게 좋을 것 같은데, 엔드포인트 고민해봐야 할 것 같습니다.

  <br/>
