### PR TITLE
[feat] 어드민이 뮤지컬 이벤트 관리하는 api 구현

### DIFF
--- a/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -34,7 +34,14 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "JOIN4001", "이미 존재하는 아이디입니다"),
 
     // AMATEURSHOW ERROR
-    AMATEURSHOW_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURSHOW4000", "존재하지 않는 소극장 공연입니다.");
+    AMATEURSHOW_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURSHOW4000", "존재하지 않는 소극장 공연입니다."),
+
+    // MUSICAL ERROR
+    MUSICAL_NOT_FOUND(HttpStatus.NOT_FOUND, "MUSICAL4000", "존재하지 않는 뮤지컬입니다."),
+
+    // MUSICAL ERROR
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT4000", "이벤트가 존재하지 않는 뮤지컬이므로 추가할 수 없습니다."),
+    EVENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "EVENT4001", "이벤트가 이미 존재하는 뮤지컬입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/muit/backend/controller/adminController/AmateurTicketController.java
+++ b/src/main/java/muit/backend/controller/adminController/AmateurTicketController.java
@@ -1,13 +1,12 @@
-package muit.backend.controller;
+package muit.backend.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.ApiResponse;
-import muit.backend.converter.AmateurTicketConverter;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketRequestDTO;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketResponseDTO;
-import muit.backend.service.AmateurTicketService;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketRequestDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketResponseDTO;
+import muit.backend.service.adminService.AmateurTicketService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,8 +25,8 @@ public class AmateurTicketController {
     @Operation(summary = "전체 소극장 티켓 조회")
     @GetMapping
     public ApiResponse<Page<AmateurTicketResponseDTO.AmateurTicketResultListDTO>> getAllTickets(@ParameterObject Pageable pageable,
-                                                                                   @RequestParam(required = false) String keyword,
-                                                                                   @RequestParam(required = false) Set<String> selectedFields) {
+                                                                                                @RequestParam(required = false) String keyword,
+                                                                                                @RequestParam(required = false) Set<String> selectedFields) {
         Page<AmateurTicketResponseDTO.AmateurTicketResultListDTO> tickets = amateurTicketService.getAllTickets(pageable, keyword, selectedFields);
         return ApiResponse.onSuccess(tickets);
     }
@@ -42,8 +41,8 @@ public class AmateurTicketController {
     @Operation(summary = "특정 소극장 티켓 정보 수정")
     @PatchMapping("/{amateurShowId}/update")
     public ApiResponse<AmateurTicketResponseDTO.AmateurTicketResultDTO> updateTicket(@PathVariable("amateurShowId") Long amateurShowId,
-                                                                        @RequestBody AmateurTicketRequestDTO.AmateurTicketUpdateDTO requestDTO) {
+                                                                                     @RequestBody AmateurTicketRequestDTO.AmateurTicketUpdateDTO requestDTO) {
         AmateurTicketResponseDTO.AmateurTicketResultDTO ticket = amateurTicketService.updateTicket(amateurShowId, requestDTO);
         return ApiResponse.onSuccess(ticket);
     }
- }
+}

--- a/src/main/java/muit/backend/controller/adminController/ManageAmateurShowController.java
+++ b/src/main/java/muit/backend/controller/adminController/ManageAmateurShowController.java
@@ -1,15 +1,13 @@
-package muit.backend.controller;
+package muit.backend.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.ApiResponse;
 import muit.backend.domain.enums.AmateurStatus;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
-import muit.backend.service.ManageAmateurShowService;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
+import muit.backend.service.adminService.ManageAmateurShowService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,8 +26,8 @@ public class ManageAmateurShowController {
     @Operation(summary = "전체 소극장 공연 조회")
     @GetMapping
     public ApiResponse<Page<ManageAmateurShowResponseDTO.ManageAmateurShowResultListDTO>> getAllAmateurShows(@ParameterObject Pageable pageable,
-                                                                                            @RequestParam(required = false) String keyword,
-                                                                                            @RequestParam(required = false) Set<String> selectedFields) {
+                                                                                                             @RequestParam(required = false) String keyword,
+                                                                                                             @RequestParam(required = false) Set<String> selectedFields) {
         Page<ManageAmateurShowResponseDTO.ManageAmateurShowResultListDTO> amateurShows = manageAmateurShowService.getAllAmateurShows(pageable, keyword, selectedFields);
         return ApiResponse.onSuccess(amateurShows);
     }

--- a/src/main/java/muit/backend/controller/adminController/ManageEventController.java
+++ b/src/main/java/muit/backend/controller/adminController/ManageEventController.java
@@ -1,0 +1,55 @@
+package muit.backend.controller.adminController;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.ApiResponse;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventRequestDTO;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventResponseDTO;
+import muit.backend.service.adminService.ManageEventService;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@Tag(name = "어드민이 이벤트 관리")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/events")
+public class ManageEventController {
+
+    private final ManageEventService manageEventService;
+
+    @Operation(summary = "이벤트가 존재하는 전체 뮤지컬 조회")
+    @GetMapping
+    public ApiResponse<Page<ManageEventResponseDTO.ManageEventResultListDTO>> getAllEvents(@ParameterObject Pageable pageable,
+                                                                                           @RequestParam(required = false) String keyword,
+                                                                                           @RequestParam(required = false) Set<String> selectedFields) {
+        Page<ManageEventResponseDTO.ManageEventResultListDTO> events = manageEventService.getAllEvents(pageable, keyword, selectedFields);
+        return ApiResponse.onSuccess(events);
+    }
+
+    @Operation(summary = "특정 뮤지컬 이벤트 상세보기")
+    @GetMapping("/{musicalId}")
+    public ApiResponse<ManageEventResponseDTO.ManageEventResultDTO> getEvent(@PathVariable("musicalId") Long musicalId) {
+        ManageEventResponseDTO.ManageEventResultDTO event = manageEventService.getEvent(musicalId);
+        return ApiResponse.onSuccess(event);
+    }
+
+    @Operation(summary = "상세보기 페이지에서 뮤지컬 이벤트 추가")
+    @PostMapping("/{musicalId}/add") // 특정 뮤지컬에 이벤트 추가
+    public ApiResponse<ManageEventResponseDTO.ManageEventResultDTO> addEvent(@PathVariable("musicalId") Long musicalId, @RequestBody ManageEventRequestDTO.ManageEventAddDTO requestDTO) {
+        ManageEventResponseDTO.ManageEventResultDTO event = manageEventService.addEvent(musicalId, requestDTO);
+        return ApiResponse.onSuccess(event);
+    }
+
+    @Operation(summary = "추가하기 버튼으로 이벤트가 있는 뮤지컬 생성")
+    @PostMapping("/create")// 이벤트가 있는 뮤지컬 생성
+    public ApiResponse<ManageEventResponseDTO.ManageEventResultDTO> createEvent(@RequestBody ManageEventRequestDTO.ManageEventCreateDTO requestDTO) {
+        ManageEventResponseDTO.ManageEventResultDTO event = manageEventService.createEvent(requestDTO);
+        return ApiResponse.onSuccess(event);
+    }
+}

--- a/src/main/java/muit/backend/controller/adminController/ManageMemberController.java
+++ b/src/main/java/muit/backend/controller/adminController/ManageMemberController.java
@@ -1,12 +1,12 @@
-package muit.backend.controller;
+package muit.backend.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.ApiResponse;
-import muit.backend.dto.manageMemberDTO.ManageMemberRequestDTO;
-import muit.backend.dto.manageMemberDTO.ManageMemberResponseDTO;
-import muit.backend.service.ManageMemberService;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberRequestDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberResponseDTO;
+import muit.backend.service.adminService.ManageMemberService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/muit/backend/controller/adminController/ManageReservController.java
+++ b/src/main/java/muit/backend/controller/adminController/ManageReservController.java
@@ -1,11 +1,11 @@
-package muit.backend.controller;
+package muit.backend.controller.adminController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.ApiResponse;
-import muit.backend.dto.manageReservDTO.ManageReservResponseDTO;
-import muit.backend.service.ManageReservService;
+import muit.backend.dto.adminDTO.manageReservDTO.ManageReservResponseDTO;
+import muit.backend.service.adminService.ManageReservService;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/muit/backend/converter/adminConverter/AmateurTicketConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/AmateurTicketConverter.java
@@ -1,7 +1,7 @@
-package muit.backend.converter;
+package muit.backend.converter.adminConverter;
 
 import muit.backend.domain.entity.amateur.AmateurShow;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketResponseDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketResponseDTO;
 
 import java.util.Set;
 

--- a/src/main/java/muit/backend/converter/adminConverter/ManageAmateurShowConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/ManageAmateurShowConverter.java
@@ -1,11 +1,7 @@
-package muit.backend.converter;
+package muit.backend.converter.adminConverter;
 
 import muit.backend.domain.entity.amateur.AmateurShow;
-import muit.backend.domain.entity.member.Member;
-import muit.backend.domain.enums.AmateurStatus;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
-import muit.backend.dto.manageMemberDTO.ManageMemberResponseDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
 
 import java.util.Set;
 

--- a/src/main/java/muit/backend/converter/adminConverter/ManageEventConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/ManageEventConverter.java
@@ -1,0 +1,68 @@
+package muit.backend.converter.adminConverter;
+
+import muit.backend.domain.entity.musical.Event;
+import muit.backend.domain.entity.musical.Musical;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventRequestDTO;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventResponseDTO;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ManageEventConverter {
+
+    public static ManageEventResponseDTO.ManageEventResultListDTO toManageEventResultListDTO(Musical musical, Set<String> selectedFields, boolean isKeywordSearch) {
+
+        // 키워드 검색이거나 전체 조회인 경우 모든 필드 포함
+        if (isKeywordSearch || selectedFields == null || selectedFields.isEmpty()) {
+            return ManageEventResponseDTO.ManageEventResultListDTO.builder()
+                    .musicalId(musical.getId())
+                    .name(musical.getName())
+                    .place(musical.getPlace())
+                    .build();
+        }
+
+        // selectedFields로 특정 필드만 선택한 경우
+        return ManageEventResponseDTO.ManageEventResultListDTO.builder()
+                .musicalId(musical.getId())  // ID는 항상 포함
+                .name(selectedFields.contains("name") ? musical.getName() : null)
+                .place(selectedFields.contains("place") ? musical.getPlace() : null)
+                .build();
+    }
+
+    public static ManageEventResponseDTO.ManageEventResultDTO toManageEventResultDTO(Musical musical) {
+
+        List<ManageEventResponseDTO.EventInfo> eventInfoList = musical.getEventList().stream()
+                .map(event -> new ManageEventResponseDTO.EventInfo(
+                        event.getEvFrom(),
+                        event.getEvTo(),
+                        event.getName()
+                ))
+                .collect(Collectors.toList());
+
+        return ManageEventResponseDTO.ManageEventResultDTO.builder()
+                .musicalId(musical.getId())
+                .musicalName(musical.getName())
+                .place(musical.getPlace())
+                .events(eventInfoList)
+                .build();
+    }
+
+    public static Event toAddEventEntity(Musical musical, ManageEventRequestDTO.ManageEventAddDTO requestDTO) {
+        return Event.builder()
+                .musical(musical) // 어떤 뮤지컬에 속한 이벤트인지 설정
+                .name(requestDTO.getName())
+                .evFrom(requestDTO.getEvFrom())
+                .evTo(requestDTO.getEvTo())
+                .build();
+    }
+
+    public static Event toCreateEventEntity(Musical musical, ManageEventRequestDTO.ManageEventCreateDTO requestDTO) {
+        return Event.builder()
+                .musical(musical)
+                .name(requestDTO.getEventName())
+                .evFrom(requestDTO.getEvFrom())
+                .evTo(requestDTO.getEvTo())
+                .build();
+    }
+}

--- a/src/main/java/muit/backend/converter/adminConverter/ManageMemberConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/ManageMemberConverter.java
@@ -1,7 +1,7 @@
-package muit.backend.converter;
+package muit.backend.converter.adminConverter;
 
 import muit.backend.domain.entity.member.Member;
-import muit.backend.dto.manageMemberDTO.ManageMemberResponseDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberResponseDTO;
 
 import java.util.Set;
 

--- a/src/main/java/muit/backend/converter/adminConverter/ManageReservConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/ManageReservConverter.java
@@ -1,9 +1,9 @@
-package muit.backend.converter;
+package muit.backend.converter.adminConverter;
 
 import muit.backend.domain.entity.amateur.AmateurShow;
 import muit.backend.domain.entity.member.MemberTicket;
 import muit.backend.domain.entity.member.Reservation;
-import muit.backend.dto.manageReservDTO.ManageReservResponseDTO;
+import muit.backend.dto.adminDTO.manageReservDTO.ManageReservResponseDTO;
 
 import java.util.Set;
 

--- a/src/main/java/muit/backend/domain/entity/amateur/AmateurShow.java
+++ b/src/main/java/muit/backend/domain/entity/amateur/AmateurShow.java
@@ -8,19 +8,21 @@ import lombok.NoArgsConstructor;
 import muit.backend.domain.common.BaseEntity;
 import muit.backend.domain.entity.member.Member;
 import muit.backend.domain.enums.AmateurStatus;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketRequestDTO;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketRequestDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Builder
+@Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class AmateurShow extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
@@ -85,11 +87,21 @@ public class AmateurShow extends BaseEntity {
 //    private List<Ticket> ticketList = new ArrayList<>();
 
     public void updateAmateurShow(ManageAmateurShowRequestDTO.ManageAmateurShowUpdateDTO requestDTO) {
-        if(requestDTO.getSchedule()!=null){this.schedule = requestDTO.getSchedule();}
-        if(requestDTO.getHashtag()!=null){this.hashtag = requestDTO.getHashtag();}
-        if(requestDTO.getContent()!=null && this.amateurSummary!=null){this.amateurSummary.updateContent(requestDTO.getContent());}
-        if(requestDTO.getContact()!=null){this.contact = requestDTO.getContact();}
-        if(requestDTO.getAmateurStatus()!=null){this.amateurStatus = requestDTO.getAmateurStatus();}
+        if (requestDTO.getSchedule() != null) {
+            this.schedule = requestDTO.getSchedule();
+        }
+        if (requestDTO.getHashtag() != null) {
+            this.hashtag = requestDTO.getHashtag();
+        }
+        if (requestDTO.getContent() != null && this.amateurSummary != null) {
+            this.amateurSummary.updateContent(requestDTO.getContent());
+        }
+        if (requestDTO.getContact() != null) {
+            this.contact = requestDTO.getContact();
+        }
+        if (requestDTO.getAmateurStatus() != null) {
+            this.amateurStatus = requestDTO.getAmateurStatus();
+        }
     }
 
     public void decideAmateurShow(AmateurStatus amateurStatus, ManageAmateurShowRequestDTO.ManageAmateurShowDecideDTO requestDTO) {
@@ -107,10 +119,18 @@ public class AmateurShow extends BaseEntity {
     }
 
     public void updateAmateurTicket(AmateurTicketRequestDTO.AmateurTicketUpdateDTO requestDTO) {
-        if(requestDTO.getName()!=null){this.name = requestDTO.getName();}
-        if(requestDTO.getSchedule()!=null){this.schedule = requestDTO.getSchedule();}
-        if(requestDTO.getSoldTicket()!=null){this.soldTicket = requestDTO.getSoldTicket();}
-        if(requestDTO.getTotalTicket()!=null){this.totalTicket = requestDTO.getTotalTicket();}
+        if (requestDTO.getName() != null) {
+            this.name = requestDTO.getName();
+        }
+        if (requestDTO.getSchedule() != null) {
+            this.schedule = requestDTO.getSchedule();
+        }
+        if (requestDTO.getSoldTicket() != null) {
+            this.soldTicket = requestDTO.getSoldTicket();
+        }
+        if (requestDTO.getTotalTicket() != null) {
+            this.totalTicket = requestDTO.getTotalTicket();
+        }
     }
 
 }

--- a/src/main/java/muit/backend/domain/entity/member/Member.java
+++ b/src/main/java/muit/backend/domain/entity/member/Member.java
@@ -7,20 +7,21 @@ import muit.backend.domain.entity.amateur.AmateurShow;
 import muit.backend.domain.enums.ActiveStatus;
 import muit.backend.domain.enums.Gender;
 import muit.backend.domain.enums.LoginType;
-import muit.backend.domain.enums.Role;
-import muit.backend.dto.manageMemberDTO.ManageMemberRequestDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberRequestDTO;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Builder
+@Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Member extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 //    @Enumerated(EnumType.STRING)
@@ -87,12 +88,26 @@ public class Member extends BaseEntity {
     }
 
     public void updateMember(ManageMemberRequestDTO.UpdateMemberRequestDTO requestDTO) {
-        if(requestDTO.getUsername()!=null){this.username = requestDTO.getUsername();}
-        if(requestDTO.getName()!=null){this.name = requestDTO.getName();}
-        if(requestDTO.getPhone()!=null){this.phone = requestDTO.getPhone();}
-        if(requestDTO.getEmail()!=null){this.email = requestDTO.getEmail();}
-        if(requestDTO.getBirthDate()!=null){this.birthDate = requestDTO.getBirthDate();}
-        if(requestDTO.getGender()!=null){this.gender = requestDTO.getGender();}
-        if(requestDTO.getAddress()!=null){this.address = requestDTO.getAddress();}
+        if (requestDTO.getUsername() != null) {
+            this.username = requestDTO.getUsername();
+        }
+        if (requestDTO.getName() != null) {
+            this.name = requestDTO.getName();
+        }
+        if (requestDTO.getPhone() != null) {
+            this.phone = requestDTO.getPhone();
+        }
+        if (requestDTO.getEmail() != null) {
+            this.email = requestDTO.getEmail();
+        }
+        if (requestDTO.getBirthDate() != null) {
+            this.birthDate = requestDTO.getBirthDate();
+        }
+        if (requestDTO.getGender() != null) {
+            this.gender = requestDTO.getGender();
+        }
+        if (requestDTO.getAddress() != null) {
+            this.address = requestDTO.getAddress();
+        }
     }
 }

--- a/src/main/java/muit/backend/dto/adminDTO/amateurTicketDTO/AmateurTicketRequestDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/amateurTicketDTO/AmateurTicketRequestDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.amateurTicketDTO;
+package muit.backend.dto.adminDTO.amateurTicketDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/muit/backend/dto/adminDTO/amateurTicketDTO/AmateurTicketResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/amateurTicketDTO/AmateurTicketResponseDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.amateurTicketDTO;
+package muit.backend.dto.adminDTO.amateurTicketDTO;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;

--- a/src/main/java/muit/backend/dto/adminDTO/manageAmateurShowDTO/ManageAmateurShowRequestDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageAmateurShowDTO/ManageAmateurShowRequestDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.manageAmateurShowDTO;
+package muit.backend.dto.adminDTO.manageAmateurShowDTO;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;

--- a/src/main/java/muit/backend/dto/adminDTO/manageAmateurShowDTO/ManageAmateurShowResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageAmateurShowDTO/ManageAmateurShowResponseDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.manageAmateurShowDTO;
+package muit.backend.dto.adminDTO.manageAmateurShowDTO;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;

--- a/src/main/java/muit/backend/dto/adminDTO/manageEventDTO/ManageEventRequestDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageEventDTO/ManageEventRequestDTO.java
@@ -1,0 +1,32 @@
+package muit.backend.dto.adminDTO.manageEventDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+public class ManageEventRequestDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ManageEventAddDTO {
+        private LocalDate evFrom; // 이벤트 시작 날짜
+        private LocalDate evTo; // 이벤트 종료 날짜
+        private String name; // 이벤트 이름
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ManageEventCreateDTO {
+        private String musicalName; // 뮤지컬 이름
+        private LocalDate evFrom; // 이벤트 시작 날짜
+        private LocalDate evTo; // 이벤트 종료 날짜
+        private String eventName; // 이벤트 이름
+    }
+}

--- a/src/main/java/muit/backend/dto/adminDTO/manageEventDTO/ManageEventResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageEventDTO/ManageEventResponseDTO.java
@@ -1,0 +1,44 @@
+package muit.backend.dto.adminDTO.manageEventDTO;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import muit.backend.domain.entity.musical.Event;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class ManageEventResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL) // null 값을 가진 필드는 JSON 응답에서 제외
+    public static class ManageEventResultListDTO {
+        private Long musicalId; // 뮤지컬 아이디
+        private String name; // 뮤지컬 이름
+        private String place; // 뮤지컬 장소
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ManageEventResultDTO {
+        private Long musicalId; // 뮤지컬 아이디
+        private String musicalName; // 뮤지컬 이름
+        private String place; // 뮤지컬 장소
+        private List<EventInfo> events; // 여러 개의 이벤트 정보를 담을 리스트
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class EventInfo {
+        private LocalDate evFrom;
+        private LocalDate evTo;
+        private String eventName;
+    }
+}

--- a/src/main/java/muit/backend/dto/adminDTO/manageMemberDTO/ManageMemberRequestDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageMemberDTO/ManageMemberRequestDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.manageMemberDTO;
+package muit.backend.dto.adminDTO.manageMemberDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/muit/backend/dto/adminDTO/manageMemberDTO/ManageMemberResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageMemberDTO/ManageMemberResponseDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.manageMemberDTO;
+package muit.backend.dto.adminDTO.manageMemberDTO;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;

--- a/src/main/java/muit/backend/dto/adminDTO/manageReservDTO/ManageReservRequestDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageReservDTO/ManageReservRequestDTO.java
@@ -1,0 +1,4 @@
+package muit.backend.dto.adminDTO.manageReservDTO;
+
+public class ManageReservRequestDTO {
+}

--- a/src/main/java/muit/backend/dto/adminDTO/manageReservDTO/ManageReservResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageReservDTO/ManageReservResponseDTO.java
@@ -1,4 +1,4 @@
-package muit.backend.dto.manageReservDTO;
+package muit.backend.dto.adminDTO.manageReservDTO;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;

--- a/src/main/java/muit/backend/dto/manageReservDTO/ManageReservRequestDTO.java
+++ b/src/main/java/muit/backend/dto/manageReservDTO/ManageReservRequestDTO.java
@@ -1,4 +1,0 @@
-package muit.backend.dto.manageReservDTO;
-
-public class ManageReservRequestDTO {
-}

--- a/src/main/java/muit/backend/repository/MusicalRepository.java
+++ b/src/main/java/muit/backend/repository/MusicalRepository.java
@@ -1,9 +1,13 @@
 package muit.backend.repository;
 
+import muit.backend.domain.entity.musical.Event;
 import muit.backend.domain.entity.musical.Musical;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventRequestDTO;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,6 +16,7 @@ import java.util.Optional;
 @Repository
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> findTop5ByOrderByIdAsc();
+
     List<Musical> findAllByOrderByIdAsc(Pageable pageable);
 
     @Query(value = "SELECT * FROM musical m WHERE m.open_date BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 7 DAY) ORDER BY m.open_date ASC", nativeQuery = true)
@@ -21,4 +26,16 @@ public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> getAllOpenAfterToday(Pageable pageable);
 
     List<Musical> findByNameContaining(String name);
+
+    // 검색어가 있을 때
+    @Query("SELECT m FROM Musical m WHERE " +
+            "m.name LIKE %:keyword% " +
+            "OR m.place LIKE %:keyword%")
+    Page<Musical> findByKeyword(Pageable pageable, @Param("keyword") String keyword);
+
+    // 이벤트가 있는 뮤지컬 전체 조회
+    @Query("SELECT DISTINCT m FROM Musical m JOIN m.eventList e WHERE e IS NOT NULL")
+    Page<Musical> findAllWithEvents(Pageable pageable);
+
+    Optional<Musical> findByName(String name);
 }

--- a/src/main/java/muit/backend/service/adminService/AmateurTicketService.java
+++ b/src/main/java/muit/backend/service/adminService/AmateurTicketService.java
@@ -1,7 +1,7 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
-import muit.backend.dto.amateurTicketDTO.AmateurTicketRequestDTO;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketResponseDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketRequestDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -12,8 +12,10 @@ import java.util.Set;
 public interface AmateurTicketService {
 
     public Page<AmateurTicketResponseDTO.AmateurTicketResultListDTO> getAllTickets(Pageable pageable,
-                                                                      String keyword,
-                                                                      Set<String> selectedFields);
+                                                                                   String keyword,
+                                                                                   Set<String> selectedFields);
+
     public AmateurTicketResponseDTO.AmateurTicketResultDTO getTicket(Long amateurShowId);
+
     public AmateurTicketResponseDTO.AmateurTicketResultDTO updateTicket(Long amateurShowId, AmateurTicketRequestDTO.AmateurTicketUpdateDTO requestDTO);
 }

--- a/src/main/java/muit/backend/service/adminService/AmateurTicketServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/AmateurTicketServiceImpl.java
@@ -1,12 +1,12 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.code.status.ErrorStatus;
 import muit.backend.apiPayLoad.exception.GeneralException;
-import muit.backend.converter.AmateurTicketConverter;
+import muit.backend.converter.adminConverter.AmateurTicketConverter;
 import muit.backend.domain.entity.amateur.AmateurShow;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketRequestDTO;
-import muit.backend.dto.amateurTicketDTO.AmateurTicketResponseDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketRequestDTO;
+import muit.backend.dto.adminDTO.amateurTicketDTO.AmateurTicketResponseDTO;
 import muit.backend.repository.AmateurShowRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,8 +24,8 @@ public class AmateurTicketServiceImpl implements AmateurTicketService {
 
     @Override
     public Page<AmateurTicketResponseDTO.AmateurTicketResultListDTO> getAllTickets(Pageable pageable,
-                                                                      String keyword,
-                                                                      Set<String> selectedFields) {
+                                                                                   String keyword,
+                                                                                   Set<String> selectedFields) {
 
         // 검색어가 있는지 확인
         boolean isKeywordSearch = keyword != null && !keyword.trim().isEmpty(); // 그냥 빈 검색어도 없다고 침
@@ -35,7 +35,7 @@ public class AmateurTicketServiceImpl implements AmateurTicketService {
         // 검색어가 있으면 해당 키워드로 검색
         if (isKeywordSearch) {
             amateurShows = amateurShowRepository.findTicketsByKeyword(pageable, keyword);
-            if(amateurShows.isEmpty()) {
+            if (amateurShows.isEmpty()) {
                 return Page.empty(pageable);
             }
         } else { // 검색어가 없으면 모든 소극장 공연 정보 조회
@@ -50,7 +50,7 @@ public class AmateurTicketServiceImpl implements AmateurTicketService {
     @Override
     public AmateurTicketResponseDTO.AmateurTicketResultDTO getTicket(Long amateurShowId) {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
         return AmateurTicketConverter.toAmateurTicketResultDTO(amateurShow);
     }
@@ -59,7 +59,7 @@ public class AmateurTicketServiceImpl implements AmateurTicketService {
     @Override
     public AmateurTicketResponseDTO.AmateurTicketResultDTO updateTicket(Long amateurShowId, AmateurTicketRequestDTO.AmateurTicketUpdateDTO requestDTO) {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
         amateurShow.updateAmateurTicket(requestDTO);
 

--- a/src/main/java/muit/backend/service/adminService/ManageAmateurShowService.java
+++ b/src/main/java/muit/backend/service/adminService/ManageAmateurShowService.java
@@ -1,9 +1,9 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
 import jakarta.validation.constraints.NotNull;
 import muit.backend.domain.enums.AmateurStatus;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,7 +14,10 @@ import java.util.Set;
 public interface ManageAmateurShowService {
 
     public Page<ManageAmateurShowResponseDTO.ManageAmateurShowResultListDTO> getAllAmateurShows(Pageable pageable, String keyword, Set<String> selectedFields);
+
     public ManageAmateurShowResponseDTO.ManageAmateurShowResultDTO getAmateurShow(Long amateurShowId);
+
     public ManageAmateurShowResponseDTO.ManageAmateurShowResultDTO updateAmateurShow(Long amateurShowId, ManageAmateurShowRequestDTO.ManageAmateurShowUpdateDTO requestDTO);
+
     public ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO decideAmateurShow(Long amateurShowId, @NotNull AmateurStatus amateurStatus, ManageAmateurShowRequestDTO.ManageAmateurShowDecideDTO requestDTO);
 }

--- a/src/main/java/muit/backend/service/adminService/ManageAmateurShowServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/ManageAmateurShowServiceImpl.java
@@ -1,14 +1,14 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.code.status.ErrorStatus;
 import muit.backend.apiPayLoad.exception.GeneralException;
-import muit.backend.converter.ManageAmateurShowConverter;
+import muit.backend.converter.adminConverter.ManageAmateurShowConverter;
 import muit.backend.domain.entity.amateur.AmateurShow;
 import muit.backend.domain.enums.AmateurStatus;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
-import muit.backend.dto.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowRequestDTO;
+import muit.backend.dto.adminDTO.manageAmateurShowDTO.ManageAmateurShowResponseDTO;
 import muit.backend.repository.AmateurShowRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +36,7 @@ public class ManageAmateurShowServiceImpl implements ManageAmateurShowService {
         // 검색어가 있으면 해당 키워드로 검색
         if (isKeywordSearch) {
             amateurShows = amateurShowRepository.findByKeyword(pageable, keyword);
-            if(amateurShows.isEmpty()) {
+            if (amateurShows.isEmpty()) {
                 return Page.empty(pageable);
             }
         } else { // 검색어가 없으면 모든 소극장 공연 정보 조회
@@ -52,7 +52,7 @@ public class ManageAmateurShowServiceImpl implements ManageAmateurShowService {
     @Override
     public ManageAmateurShowResponseDTO.ManageAmateurShowResultDTO getAmateurShow(Long amateurShowId) {
         AmateurShow amateurShow = amateurShowRepository.findByIdWithMemberAndSummary(amateurShowId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
         return ManageAmateurShowConverter.toManageAmateurShowResultDTO(amateurShow);
     }
@@ -62,7 +62,7 @@ public class ManageAmateurShowServiceImpl implements ManageAmateurShowService {
     @Override
     public ManageAmateurShowResponseDTO.ManageAmateurShowResultDTO updateAmateurShow(Long amateurShowId, ManageAmateurShowRequestDTO.ManageAmateurShowUpdateDTO requestDTO) {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
         amateurShow.updateAmateurShow(requestDTO);
 
@@ -74,7 +74,7 @@ public class ManageAmateurShowServiceImpl implements ManageAmateurShowService {
     @Override
     public ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO decideAmateurShow(Long amateurShowId, @NotNull AmateurStatus amateurStatus, ManageAmateurShowRequestDTO.ManageAmateurShowDecideDTO requestDTO) {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
         amateurShow.decideAmateurShow(amateurStatus, requestDTO);
         return ManageAmateurShowConverter.toManageAmateurShowDecideDTO(amateurShow);

--- a/src/main/java/muit/backend/service/adminService/ManageEventService.java
+++ b/src/main/java/muit/backend/service/adminService/ManageEventService.java
@@ -1,0 +1,21 @@
+package muit.backend.service.adminService;
+
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventRequestDTO;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+public interface ManageEventService {
+
+    public Page<ManageEventResponseDTO.ManageEventResultListDTO> getAllEvents(Pageable pageable, String keyword, Set<String> selectedFields);
+
+    public ManageEventResponseDTO.ManageEventResultDTO getEvent(Long musicalId);
+
+    public ManageEventResponseDTO.ManageEventResultDTO addEvent(Long musicalId, ManageEventRequestDTO.ManageEventAddDTO requestDTO);
+
+    public ManageEventResponseDTO.ManageEventResultDTO createEvent(ManageEventRequestDTO.ManageEventCreateDTO requestDTO);
+}

--- a/src/main/java/muit/backend/service/adminService/ManageEventServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/ManageEventServiceImpl.java
@@ -1,0 +1,83 @@
+package muit.backend.service.adminService;
+
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.code.status.ErrorStatus;
+import muit.backend.apiPayLoad.exception.GeneralException;
+import muit.backend.converter.adminConverter.ManageEventConverter;
+import muit.backend.domain.entity.musical.Event;
+import muit.backend.domain.entity.musical.Musical;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventRequestDTO;
+import muit.backend.dto.adminDTO.manageEventDTO.ManageEventResponseDTO;
+import muit.backend.repository.EventRepository;
+import muit.backend.repository.MusicalRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManageEventServiceImpl implements ManageEventService {
+
+    private final MusicalRepository musicalRepository;
+    private final EventRepository eventRepository;
+
+    // 전체 이벤트 조회
+    @Override
+    public Page<ManageEventResponseDTO.ManageEventResultListDTO> getAllEvents(Pageable pageable, String keyword, Set<String> selectedFields) {
+
+        // 검색어가 있는지 확인
+        boolean isKeywordSearch = keyword != null && !keyword.trim().isEmpty(); // 빈 검색어도 없다고 침
+
+        Page<Musical> musicals;
+
+        // 검색어가 있으면 해당 키워드로 검색
+        if (isKeywordSearch) {
+            musicals = musicalRepository.findByKeyword(pageable, keyword);
+            if (musicals.isEmpty()) {
+                return Page.empty(pageable);
+            }
+        } else {// 검색어가 없으면 모든 이벤트 가진 뮤지컬 정보 조회
+            musicals = musicalRepository.findAllWithEvents(pageable);
+        }
+
+        return musicals.map(musical -> ManageEventConverter.toManageEventResultListDTO(musical, selectedFields, isKeywordSearch));
+    }
+
+    // 특정 이벤트 조회
+    @Override
+    public ManageEventResponseDTO.ManageEventResultDTO getEvent(Long musicalId) {
+        Musical musical = musicalRepository.findById(musicalId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MUSICAL_NOT_FOUND));
+
+        return ManageEventConverter.toManageEventResultDTO(musical);
+    }
+
+    // 특정 뮤지컬에 이벤트 추가 (상세페이지)
+    @Override
+    @Transactional
+    public ManageEventResponseDTO.ManageEventResultDTO addEvent(Long musicalId, ManageEventRequestDTO.ManageEventAddDTO requestDTO) {
+        Musical musical = musicalRepository.findById(musicalId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MUSICAL_NOT_FOUND));
+
+        Event event = ManageEventConverter.toAddEventEntity(musical, requestDTO);
+        eventRepository.save(event);
+        return ManageEventConverter.toManageEventResultDTO(musical);
+    }
+
+    // 이벤트가 있는 뮤지컬 생성
+    @Override
+    @Transactional
+    public ManageEventResponseDTO.ManageEventResultDTO createEvent(ManageEventRequestDTO.ManageEventCreateDTO requestDTO) {
+        Musical musical = musicalRepository.findByName(requestDTO.getMusicalName())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MUSICAL_NOT_FOUND));
+
+        Event event = ManageEventConverter.toCreateEventEntity(musical, requestDTO);
+        eventRepository.save(event);
+        return ManageEventConverter.toManageEventResultDTO(musical);
+    }
+
+}

--- a/src/main/java/muit/backend/service/adminService/ManageMemberService.java
+++ b/src/main/java/muit/backend/service/adminService/ManageMemberService.java
@@ -1,7 +1,7 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
-import muit.backend.dto.manageMemberDTO.ManageMemberRequestDTO;
-import muit.backend.dto.manageMemberDTO.ManageMemberResponseDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberRequestDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;

--- a/src/main/java/muit/backend/service/adminService/ManageMemberServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/ManageMemberServiceImpl.java
@@ -1,13 +1,13 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
 
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.code.status.ErrorStatus;
 import muit.backend.apiPayLoad.exception.GeneralException;
-import muit.backend.converter.ManageMemberConverter;
+import muit.backend.converter.adminConverter.ManageMemberConverter;
 import muit.backend.domain.entity.member.Member;
-import muit.backend.dto.manageMemberDTO.ManageMemberRequestDTO;
-import muit.backend.dto.manageMemberDTO.ManageMemberResponseDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberRequestDTO;
+import muit.backend.dto.adminDTO.manageMemberDTO.ManageMemberResponseDTO;
 import muit.backend.repository.MemberRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,7 +52,7 @@ public class ManageMemberServiceImpl implements ManageMemberService {
     @Override
     public ManageMemberResponseDTO.ManageMemberResultDTO getMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         return ManageMemberConverter.toManageMemberResultDTO(member);
     }
@@ -62,7 +62,7 @@ public class ManageMemberServiceImpl implements ManageMemberService {
     @Transactional
     public ManageMemberResponseDTO.ManageMemberResultDTO updateMember(Long memberId, ManageMemberRequestDTO.UpdateMemberRequestDTO requestDTO) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         member.updateMember(requestDTO);
 

--- a/src/main/java/muit/backend/service/adminService/ManageReservService.java
+++ b/src/main/java/muit/backend/service/adminService/ManageReservService.java
@@ -1,6 +1,6 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
-import muit.backend.dto.manageReservDTO.ManageReservResponseDTO;
+import muit.backend.dto.adminDTO.manageReservDTO.ManageReservResponseDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;

--- a/src/main/java/muit/backend/service/adminService/ManageReservServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/ManageReservServiceImpl.java
@@ -1,11 +1,9 @@
-package muit.backend.service;
+package muit.backend.service.adminService;
 
 import lombok.RequiredArgsConstructor;
-import muit.backend.converter.AmateurTicketConverter;
-import muit.backend.converter.ManageReservConverter;
-import muit.backend.domain.entity.amateur.AmateurShow;
+import muit.backend.converter.adminConverter.ManageReservConverter;
 import muit.backend.domain.entity.member.Reservation;
-import muit.backend.dto.manageReservDTO.ManageReservResponseDTO;
+import muit.backend.dto.adminDTO.manageReservDTO.ManageReservResponseDTO;
 import muit.backend.repository.ReservationRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +30,7 @@ public class ManageReservServiceImpl implements ManageReservService {
         // 검색어가 있으면 해당 키워드로 검색
         if (isKeywordSearch) {
             reservations = reservationRepository.findByKeyword(pageable, keyword);
-            if(reservations.isEmpty()) {
+            if (reservations.isEmpty()) {
                 return Page.empty(pageable);
             }
         } else { // 검색어가 없으면 모든 소극장 공연 정보 조회


### PR DESCRIPTION
## 🔎 작업 내용

- 이벤트가 존재하는 뮤지컬 전체 조회 api
- 상세보기 페이지에서 뮤지컬 이벤트 추가 (생성) api
-  전체 리스트의 추가하기 버튼으로 이벤트가 있는 뮤지컬 생성 api
- 특정 뮤지컬의 이벤트 상세보기 api
- 그리고 제가 어드민 관련 파일들 너무 많이 만들어성.. 이름도 헷갈리고 그래서 어드민 디렉토리 안에 다 옮겼습니다.
  <br/>

## 🔧 Todo

- 예외처리 더 세분화하기 (특정 상황에서의 예외처리가 추가적으로 더 필요한데 이걸 넣으면 현재 response에 db 바뀐 결과가 반영되지 않는 문제가 생겨서 일단 제거했습니다. 추후 추가하겠습니다)
- 상세보기 post 말고 patch로 수정