### PR TITLE
[feat] jwt 토큰 사용해 로그인 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	//testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -55,6 +55,23 @@ dependencies {
 
 	//jsoup
 	implementation 'org.jsoup:jsoup:1.15.3'
+
+	//sercurity
+	//implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//DNS
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.100.Final:osx-aarch_64'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/muit/backend/config/jwt/JwtFilter.java
+++ b/src/main/java/muit/backend/config/jwt/JwtFilter.java
@@ -1,0 +1,68 @@
+package muit.backend.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+            throws IOException, ServletException {
+
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 1. Request Header 에서 토큰을 꺼냄
+        String jwt = resolveToken(request);
+
+        // 2. validateToken 으로 토큰 유효성 검사
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    // Request Header 에서 토큰 정보를 꺼내오기
+    /*private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.split(" ")[1].trim();
+        }
+        return null;
+    }*/
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.split(" ")[1].trim();
+        }
+        return null;
+    }
+    // 제발되라
+}

--- a/src/main/java/muit/backend/config/jwt/JwtSecurityConfig.java
+++ b/src/main/java/muit/backend/config/jwt/JwtSecurityConfig.java
@@ -1,0 +1,24 @@
+package muit.backend.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig implements SecurityConfigurer<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void init(HttpSecurity builder) throws Exception {
+        System.out.println("JWT security init");
+    }
+
+    // TokenProvider 를 주입받아서 JwtFilter 를 통해 Security 로직에 필터를 등록
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/muit/backend/config/jwt/SecurityConfig.java
+++ b/src/main/java/muit/backend/config/jwt/SecurityConfig.java
@@ -1,0 +1,59 @@
+package muit.backend.config.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final TokenProvider tokenProvider;
+    private final JwtFilter jwtFilter;
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+                .cors(cors -> cors.configurationSource(request -> {
+                    CorsConfiguration config = new CorsConfiguration();
+                    config.setAllowCredentials(true);
+                    config.addAllowedOrigin("http://localhost:8080"); // '*' 대신 명시적 출처 사용
+                    config.addAllowedOrigin("http://localhost:5173"); // '*' 대신 명시적 출처 사용
+
+                    //config.addAllowedOrigin("*");
+                    config.addAllowedHeader("*");
+                    config.addAllowedMethod("*");
+                    return config;
+                }))
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .httpBasic(httpBasic -> httpBasic.disable()) // HTTP Basic 비활성화
+                .formLogin(formLogin -> formLogin.disable()) // 폼 로그인 비활성화
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/**").permitAll()  // 이 경로들은 인증 없이 접근 허용
+                        .anyRequest().authenticated()  // 그 외의 모든 요청은 인증 필요
+                )
+                .apply(new JwtSecurityConfig(tokenProvider));
+        http
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class); // JwtFilter 등록
+
+        return http.build();
+    }
+
+
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+

--- a/src/main/java/muit/backend/config/jwt/TokenDTO.java
+++ b/src/main/java/muit/backend/config/jwt/TokenDTO.java
@@ -1,0 +1,11 @@
+package muit.backend.config.jwt;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class TokenDTO {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/muit/backend/config/jwt/TokenProvider.java
+++ b/src/main/java/muit/backend/config/jwt/TokenProvider.java
@@ -1,0 +1,106 @@
+package muit.backend.config.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 5;            // 5시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final Key key;
+
+    public TokenProvider(@Value("${jwt.secret}") String secretKey) {
+        log.info("JWT Secret Key (Generation): {}", secretKey); // Secret Key 출력
+
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenDTO generateTokenDto(Authentication authentication) {
+        // 권한들 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())       // payload "sub": "name"
+                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)        // payload "exp": 151621022 (ex)
+                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
+                .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDTO.builder()
+                //.grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                //.accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
+    }
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        // 권한 정보 없이 UserDetails 생성
+        UserDetails principal = new User(claims.getSubject(), "", new ArrayList<>());
+
+        return new UsernamePasswordAuthenticationToken(principal, "", principal.getAuthorities());
+    }
+
+
+
+    public boolean validateToken(String token) {
+        log.info("JWT Secret Key (Validation): {}", Base64.getEncoder().encodeToString(key.getEncoded())); // Secret Key 출력
+
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}
+

--- a/src/main/java/muit/backend/controller/MemberController.java
+++ b/src/main/java/muit/backend/controller/MemberController.java
@@ -2,15 +2,12 @@ package muit.backend.controller;
 
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.ApiResponse;
-import muit.backend.dto.memberDTO.EmailRegisterRequestDTO;
-import muit.backend.dto.memberDTO.EmailRegisterResponseDTO;
+import muit.backend.domain.entity.member.Member;
+import muit.backend.dto.memberDTO.*;
 import muit.backend.service.MemberService;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +29,28 @@ public class MemberController {
             return ApiResponse.onFailure("400", e.getMessage(), null);
         }
     }
+
+    @PostMapping("/email/login")  // JWT 토큰을 생성하여 반환
+    public ApiResponse<EmailLoginAccessTokenResponse> login(@RequestBody LoginRequestDTO dto) {
+        try {
+            //TokenDto tokenDto = memberService.login(dto);
+            EmailLoginAccessTokenResponse result = memberService.EmailLogin(dto);
+            return ApiResponse.onSuccess(result);
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.onFailure("400", e.getMessage(), null);
+        } catch (Exception e) {
+            return ApiResponse.onFailure("500", e.getMessage(),null);
+        }
+    }
+
+    @GetMapping("/{memberId}")
+    public ApiResponse<MyPageResponseDTO> myPage(@RequestHeader("Authorization") String authorizationHeader, @PathVariable("memberId") Long memberId) {
+        Member member = memberService.getMemberByToken(authorizationHeader);
+        MyPageResponseDTO myPageResponseDTO = memberService.getMyPage(member.getId(), memberId);
+
+        return ApiResponse.onSuccess(myPageResponseDTO);
+    }
+
 
 
 

--- a/src/main/java/muit/backend/converter/MemberConverter.java
+++ b/src/main/java/muit/backend/converter/MemberConverter.java
@@ -1,18 +1,21 @@
 package muit.backend.converter;
 
+import muit.backend.config.jwt.TokenDTO;
 import muit.backend.domain.entity.member.Member;
+import muit.backend.dto.memberDTO.EmailLoginAccessTokenResponse;
 import muit.backend.dto.memberDTO.EmailRegisterRequestDTO;
 import muit.backend.dto.memberDTO.EmailRegisterResponseDTO;
 
 public class MemberConverter {
 
-    public static Member EmailtoMember(EmailRegisterRequestDTO dto){
+    public static Member EmailtoMember(EmailRegisterRequestDTO dto, String encodedPassword){
         return Member.builder()
                 .username(dto.getUsername())
                 .name(dto.getName())
-                .password(dto.getPw())
+                .password(encodedPassword)
                 .email(dto.getEmail())
                 .phone(dto.getPhone())
+                .oauthProvider("MUIT")
                 .address(dto.getAddress()).build();
     }
 
@@ -20,5 +23,15 @@ public class MemberConverter {
         return EmailRegisterResponseDTO.builder()
                 .id(member.getId())
                 .email(member.getEmail()).build();
+    }
+
+    public static EmailLoginAccessTokenResponse TokenLoginResponseDTO(TokenDTO dto, Member member){
+        return EmailLoginAccessTokenResponse.builder()
+                .accessToken(dto.getAccessToken())
+                .refreshToken(dto.getRefreshToken())
+                .id(member.getId())
+                .name(member.getName())
+                .username(member.getUsername())
+                .build();
     }
 }

--- a/src/main/java/muit/backend/domain/entity/member/Member.java
+++ b/src/main/java/muit/backend/domain/entity/member/Member.java
@@ -53,6 +53,9 @@ public class Member extends BaseEntity {
 
     //private String deliveryAddress;
 
+    private String oauthProvider;
+
+
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'ACTIVE'")
     private ActiveStatus activeStatus;

--- a/src/main/java/muit/backend/dto/memberDTO/EmailLoginAccessTokenResponse.java
+++ b/src/main/java/muit/backend/dto/memberDTO/EmailLoginAccessTokenResponse.java
@@ -10,6 +10,7 @@ public class EmailLoginAccessTokenResponse {
     private String accessToken;
     private String refreshToken;
     private Long id;
-
+    private String username;
+    private String name;
 }
 

--- a/src/main/java/muit/backend/dto/memberDTO/MyPageResponseDTO.java
+++ b/src/main/java/muit/backend/dto/memberDTO/MyPageResponseDTO.java
@@ -1,0 +1,16 @@
+package muit.backend.dto.memberDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class MyPageResponseDTO {
+    private Long id;
+    private String name;
+    private String username;
+}

--- a/src/main/java/muit/backend/repository/MemberRepository.java
+++ b/src/main/java/muit/backend/repository/MemberRepository.java
@@ -26,4 +26,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("select m from Member m where m.email = :email")
     Optional<Member> findMemberByEmail(@Param("email") String email);
+
+
+    @Query("select m from Member m where m.email = :mail and m.oauthProvider = :oauth")
+    Optional<Member> checkEmail(@Param("mail") String mail, @Param("oauth") String oauth);
 }

--- a/src/main/java/muit/backend/service/MemberService.java
+++ b/src/main/java/muit/backend/service/MemberService.java
@@ -1,9 +1,13 @@
 package muit.backend.service;
 
-import muit.backend.dto.memberDTO.EmailRegisterRequestDTO;
-import muit.backend.dto.memberDTO.EmailRegisterResponseDTO;
+import muit.backend.domain.entity.member.Member;
+import muit.backend.dto.memberDTO.*;
 
 public interface MemberService {
     public EmailRegisterResponseDTO emailSignUp(EmailRegisterRequestDTO dto);
+    public Member findById(Long id);
+    public EmailLoginAccessTokenResponse EmailLogin(LoginRequestDTO dto);
+    public Member getMemberByToken(String token);
+    public MyPageResponseDTO getMyPage(Long tokenId, Long memberId);
 
 }

--- a/src/main/java/muit/backend/service/MemberServiceImpl.java
+++ b/src/main/java/muit/backend/service/MemberServiceImpl.java
@@ -1,11 +1,19 @@
 package muit.backend.service;
 
 import lombok.RequiredArgsConstructor;
+
+import muit.backend.apiPayLoad.code.status.ErrorStatus;
+import muit.backend.apiPayLoad.exception.GeneralException;
+import muit.backend.config.jwt.TokenDTO;
+import muit.backend.config.jwt.TokenProvider;
 import muit.backend.converter.MemberConverter;
 import muit.backend.domain.entity.member.Member;
-import muit.backend.dto.memberDTO.EmailRegisterRequestDTO;
-import muit.backend.dto.memberDTO.EmailRegisterResponseDTO;
+import muit.backend.dto.memberDTO.*;
 import muit.backend.repository.MemberRepository;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,10 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder encoder;
+    private final TokenProvider tokenProvider;
 
+    //== 개인회원 가입 - 이메일 ==//
     @Override
     @Transactional
-    public EmailRegisterResponseDTO emailSignUp(EmailRegisterRequestDTO dto){
+    public EmailRegisterResponseDTO emailSignUp(EmailRegisterRequestDTO dto) {
 
         if (memberRepository.findByEmail(dto.getEmail()).isPresent()) {
             throw new IllegalStateException("이미 사용 중인 이메일입니다.");
@@ -26,12 +37,89 @@ public class MemberServiceImpl implements MemberService {
             throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
         }
 
-        Member member = MemberConverter.EmailtoMember(dto);
+        String encodedPw = encoder.encode(dto.getPw());
+        Member member = MemberConverter.EmailtoMember(dto, encodedPw);
         memberRepository.save(member);
 
         return MemberConverter.MemberToEmailRegisterResponseDTO(member);
 
     }
 
+    @Override
+    public Member findById(Long id) {
+        return memberRepository.findById(id).orElseThrow(() -> new IllegalStateException("unexpected member"));
+    }
+
+
+    //== 이메일 로그인 == //
+    @Override
+    public EmailLoginAccessTokenResponse EmailLogin(LoginRequestDTO dto){
+
+        String email = dto.getEmail();
+        TokenDTO token = login(dto);
+        Member member = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Member with email " + email + " not found."));
+        return MemberConverter.TokenLoginResponseDTO(token, member);
+    }
+
+    // 1. 로그인 메서드
+    public TokenDTO login(LoginRequestDTO dto) {
+
+        String clientEmail = dto.getEmail();
+        String clientPw = dto.getPw();
+
+        // 해당 이메일이 있는지 검증
+        Member member = memberRepository.checkEmail(clientEmail, "MUIT")
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!encoder.matches(clientPw, member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호 불일치");
+        }
+
+
+        // 사용자 인증에 성공하면 JWT 토큰 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(clientEmail, null);
+        return tokenProvider.generateTokenDto(authentication);
+    }
+
+    // == 회원 검증 로직 == //
+    @Override
+    public Member getMemberByToken(String token) {
+        // 토큰이 유효한지 검증
+        if (!tokenProvider.validateToken(token)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        // 토큰에서 인증 정보를 추출
+        Authentication authentication = tokenProvider.getAuthentication(token);
+
+        // 인증 정보에서 사용자 이메일을 가져와 회원 조회
+        String email = authentication.getName();
+        System.out.println("회원조회 체크 "+email);
+
+        return memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+    }
+
+
+    @Override
+    public MyPageResponseDTO getMyPage(Long tokenId, Long  memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+        if (!tokenId.equals(memberId)) {
+            throw new IllegalArgumentException("요청된 회원 ID와 인증된 회원 ID가 일치하지 않습니다.");
+        }
+        return MyPageResponseDTO.builder()
+                .id(memberId)
+                .name(member.getName())
+                .username(member.getUsername()).build();
+    }
+
+
+
+
+
 
 }
+
+


### PR DESCRIPTION
### 1. 회원 가입
- 반드시 비밀 번호를 기억해 주세요! 복호화 된 채로 DB에 저장 됩니다.
- 비밀번호 잃어 버려서 쓸모 없어진 데이터는 삭제해도 좋습니다.
- 이메일 입력시 형식만 맞춰 주시면 됩니다. ex) [hy@abc.com](mailto:hy@abc.com)
- 이메일인증/회원가입 -> 다른 url입니다!!

### 2. 로그인
이메일, 비밀 번호 치시면 됩니다. return하는 token에 대한 설명은 노션에 적을게요.


### 3. 사용자 인증
작업 하시다가 현재 로그인한 사용자의 정보가 필요할 때가 있으실 텐데, 마찬가지로 노션에 정리하겠습니다.