### PR TITLE
[feat] 인기 게시판 + 게시글 좋아요 구현

### DIFF
--- a/src/main/java/muit/backend/controller/postController/CommonPostController.java
+++ b/src/main/java/muit/backend/controller/postController/CommonPostController.java
@@ -1,0 +1,42 @@
+package muit.backend.controller.postController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.ApiResponse;
+import muit.backend.domain.entity.member.Member;
+import muit.backend.domain.entity.member.Post;
+import muit.backend.domain.enums.PostType;
+import muit.backend.dto.postDTO.PostResponseDTO;
+import muit.backend.service.MemberService;
+import muit.backend.service.postService.PostService;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "게시글 공통")
+@RestController
+@RequiredArgsConstructor
+public class CommonPostController {
+
+    private final PostService postService;
+    private final MemberService memberService;
+
+    @GetMapping("/likes/{postId}")
+    @Operation(summary = "게시판 좋아요 API", description = "익명 게시판의 게시글 좋아요/좋아요 취소 API")
+    public ApiResponse<PostResponseDTO.likeResultDTO> likePost(@RequestHeader("Authorization") String accessToken,
+                                                                      @PathVariable("postId") Long postId)
+    {
+        Member member = memberService.getMemberByToken(accessToken);
+        return ApiResponse.onSuccess(postService.likePost(postId, member));
+    }
+
+    @DeleteMapping("/delete/{postId}")
+    @Operation(summary = "게시글 삭제 API", description = "특정 사용자가 작성한 특정 게시글을 삭제하는 API 입니다.")
+    public ApiResponse<PostResponseDTO.DeleteResultDTO> deletePost(@RequestHeader("Authorization") String accessToken,
+                                                                   @PathVariable("postId") Long postId) {
+        Member member = memberService.getMemberByToken(accessToken);
+        return ApiResponse.onSuccess(postService.deletePost(postId, member));
+    }
+
+}

--- a/src/main/java/muit/backend/controller/postController/LostController.java
+++ b/src/main/java/muit/backend/controller/postController/LostController.java
@@ -51,7 +51,7 @@ public class LostController {
     }
 
     @GetMapping("")
-    @Operation(summary = "게시판 게시글 리스트 조회 API", description = "특정 게시판의 게시글 목록을 조회하는 API 이며 query string 으로 postType과 page를 받음")
+    @Operation(summary = "게시판 게시글 리스트 조회 API", description = "특정 게시판의 게시글 목록을 조회하는 API")
     @Parameters({
             @Parameter(name = "postType", description = "게시판 종류, LOST, FOUND 중에 선택"),
             @Parameter( name = "page", description = "페이지를 정수로 입력"),

--- a/src/main/java/muit/backend/controller/postController/PostController.java
+++ b/src/main/java/muit/backend/controller/postController/PostController.java
@@ -49,20 +49,25 @@ public class PostController {
             @Parameter(name = "search", description = "검색어")
     })
     public ApiResponse<PostResponseDTO.PostResultListDTO> getPostList( @RequestHeader("Authorization") String accessToken,
+                                                                       @RequestParam("postType") BlindType blindType,
                                                                        @RequestParam(defaultValue = "0", name = "page") Integer page,
                                                                        @RequestParam(defaultValue = "20", name = "size")Integer size,
                                                                        @RequestParam(defaultValue = "" ,name = "search") String search)
     {
-        memberService.getMemberByToken(accessToken);
-        return ApiResponse.onSuccess(postService.getPostList(PostType.BLIND, page,size, search));
+        Member member = memberService.getMemberByToken(accessToken);
+        if(blindType.equals(BlindType.BLIND)){
+            return ApiResponse.onSuccess(postService.getPostList(PostType.BLIND, page,size, search, member));}
+        else{
+            return ApiResponse.onSuccess(postService.getHotPostList(PostType.BLIND, page,size, search, member));
+        }
     }
 
     @GetMapping("/{postId}")
     @Operation(summary = "익명 게시글 단건 조회 API", description = "익명 게시판의 특정 게시글을 조회하는 API 입니다.")
     public ApiResponse<PostResponseDTO.GeneralPostResponseDTO> getPost(@RequestHeader("Authorization") String accessToken,
                                                                        @PathVariable("postId") Long postId) {
-        memberService.getMemberByToken(accessToken);
-        return ApiResponse.onSuccess(postService.getPost(postId));
+        Member member = memberService.getMemberByToken(accessToken);
+        return ApiResponse.onSuccess(postService.getPost(postId, member));
     }
 
 
@@ -74,14 +79,6 @@ public class PostController {
                                                                         @RequestPart(name = "imageFiles", required = false)List<MultipartFile> img) {
         Member member = memberService.getMemberByToken(accessToken);
         return ApiResponse.onSuccess(postService.editPost(postId, postRequestDTO, img, member));
-    }
-
-    @DeleteMapping("/{postId}")
-    @Operation(summary = "게시글 삭제 API", description = "특정 사용자가 작성한 특정 게시글을 삭제하는 API 입니다.")
-    public ApiResponse<PostResponseDTO.DeleteResultDTO> deletePost(@RequestHeader("Authorization") String accessToken,
-                                                                   @PathVariable("postId") Long postId) {
-        Member member = memberService.getMemberByToken(accessToken);
-        return ApiResponse.onSuccess(postService.deletePost(postId, member));
     }
 
 }

--- a/src/main/java/muit/backend/converter/postConverter/PostConverter.java
+++ b/src/main/java/muit/backend/converter/postConverter/PostConverter.java
@@ -8,6 +8,7 @@ import muit.backend.dto.postDTO.PostResponseDTO;
 import muit.backend.s3.UuidFile;
 import org.springframework.data.domain.Page;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,15 +28,17 @@ public class PostConverter {
                 .title(requestDTO.getTitle())
                 .content(requestDTO.getContent())
                 .commentCount(0)
+                .postLikes(new ArrayList<>())
                 .images(imgList)
                 .build();
     }
 
     // Entity -> ResultDTO
     // 게시글 조회 - 단건
-    public static PostResponseDTO.GeneralPostResponseDTO toGeneralPostResponseDTO(Post post) {
+    public static PostResponseDTO.GeneralPostResponseDTO toGeneralPostResponseDTO(Post post,boolean isLiked) {
 
         String name = post.getIsAnonymous() ? "익명" :post.getMember().getName();
+
         return PostResponseDTO.GeneralPostResponseDTO.builder()
                 .id(post.getId())
                 .memberId(post.getMember().getId())
@@ -44,24 +47,10 @@ public class PostConverter {
                 .content(post.getContent())
                 .imgUrls(post.getImages().stream().map(UuidFile::getFileUrl).collect(Collectors.toList()))
                 .commentCount(post.getCommentCount())
+                .likeCount(post.getPostLikes().size())
+                .isLiked(isLiked)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();
     }
-
-    // List<Entity> -> ResultListDTO
-    //게시판 조회 - 리스트
-    public static PostResponseDTO.PostResultListDTO toPostResultListDTO(Page<Post> postPage) {
-        List<PostResponseDTO.GeneralPostResponseDTO> postResultListDTO = postPage.stream()
-                .map(PostConverter::toGeneralPostResponseDTO).collect(Collectors.toList());
-
-        return PostResponseDTO.PostResultListDTO.builder()
-                .posts(postResultListDTO)
-                .listSize(postResultListDTO.size())
-                .isFirst(postPage.isFirst())
-                .isLast(postPage.isLast())
-                .totalPage(postPage.getTotalPages())
-                .totalElements(postPage.getTotalElements())
-                .build();
-    };
 }

--- a/src/main/java/muit/backend/domain/entity/member/Post.java
+++ b/src/main/java/muit/backend/domain/entity/member/Post.java
@@ -52,6 +52,8 @@ public class Post extends BaseEntity {
 
     private String lostItem;
 
+    private Integer likes;
+
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UuidFile> images = new ArrayList<>();
 
@@ -59,7 +61,7 @@ public class Post extends BaseEntity {
     private List<Comment> commentList = new ArrayList<>();
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<PostLikes> postLikesList = new ArrayList<>();
+    private List<PostLikes> postLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Report> reportList = new ArrayList<>();

--- a/src/main/java/muit/backend/dto/postDTO/PostResponseDTO.java
+++ b/src/main/java/muit/backend/dto/postDTO/PostResponseDTO.java
@@ -22,6 +22,8 @@ public class PostResponseDTO {
         private String content;
         private List<String> imgUrls;
         private Integer commentCount;
+        private Integer likeCount;
+        private Boolean isLiked;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }
@@ -45,5 +47,12 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class DeleteResultDTO {
         private String message;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class likeResultDTO {
+        private Boolean isLiked;
     }
 }

--- a/src/main/java/muit/backend/repository/PostLikesRepository.java
+++ b/src/main/java/muit/backend/repository/PostLikesRepository.java
@@ -1,0 +1,10 @@
+package muit.backend.repository;
+
+import muit.backend.domain.entity.member.Member;
+import muit.backend.domain.entity.member.Post;
+import muit.backend.domain.entity.member.PostLikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikesRepository extends JpaRepository<PostLikes, Integer> {
+    PostLikes findByMemberAndPost(Member member, Post post);
+}

--- a/src/main/java/muit/backend/repository/PostRepository.java
+++ b/src/main/java/muit/backend/repository/PostRepository.java
@@ -1,11 +1,13 @@
 package muit.backend.repository;
 
-import muit.backend.domain.entity.member.Inquiry;
 import muit.backend.domain.entity.member.Post;
 import muit.backend.domain.enums.PostType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -16,6 +18,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     //익명 + 핫게용
     Page<Post> findAllByPostTypeAndTitleContaining(PostType postType, String title, PageRequest pageRequest);
+
+    @Query("SELECT p.post FROM PostLikes p GROUP BY p.post.id HAVING COUNT(p)>=2")
+    Page<Post> findAllHot(@Param("title") String title, Pageable pageable);
+
+
 
     //분실물용
     Page<Post> findAllByPostTypeAndMusicalNameAndLostItemContainingAndLocationContaining(PostType postType, PageRequest of, String musicalName, String lostItem, String location);

--- a/src/main/java/muit/backend/service/postService/PostService.java
+++ b/src/main/java/muit/backend/service/postService/PostService.java
@@ -12,10 +12,12 @@ import java.util.List;
 @Service
 public interface PostService {
     //특정 게시글 조회
-    public PostResponseDTO.GeneralPostResponseDTO getPost(Long PostId);
+    public PostResponseDTO.GeneralPostResponseDTO getPost(Long PostId, Member member);
 
     //게시판 조회
-    public PostResponseDTO.PostResultListDTO getPostList(PostType postType, Integer page, Integer size, String search);
+    public PostResponseDTO.PostResultListDTO getPostList(PostType postType, Integer page, Integer size, String search, Member member);
+    //핫게시판 조회
+    PostResponseDTO.PostResultListDTO getHotPostList(PostType postType, Integer page, Integer size, String search, Member member);
 
     //게시글 생성
     public PostResponseDTO.GeneralPostResponseDTO createPost(PostType postType, PostRequestDTO postRequestDTO, List<MultipartFile> img, Member member);
@@ -25,4 +27,6 @@ public interface PostService {
 
     //게시글 수정
     public PostResponseDTO.GeneralPostResponseDTO editPost(Long postId, PostRequestDTO postRequestDTO, List<MultipartFile> img, Member member);
+
+    PostResponseDTO.likeResultDTO likePost(Long postId, Member member);
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 인기 게시글 리턴할 수 있도록 합니다.<br/>(기존 익명 게시판 API에서 postType = HOT 으로 쿼리스트링 넣을 시 반환합니다.)
- 좋아요 구현합니다.
- 좋아요 기능 추가에 따른 DTO 수정합니다: <br/>로그인한 멤버에 따라 게시글에 대한 자신의 좋아요 여부인 isLiked와 게시글의 총 좋아요 수를 반환합니다.

  <br/>

## 🔧 Todo

- **현재 멤버수가 적기 때문에 2개 이상 좋아요를 받으면 인기 게시글로 등록되도록 했습니다.**<br/>후에 멤버가 좀 많아지면 기준을 10으로 바꾸겠습니다.

