### PR TITLE
[feat] 어드민이 문의 내역 관리

### DIFF
--- a/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -36,16 +36,15 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //COMMENT ERROR
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4000", "존재하지 않는 댓글입니다."),
-    
+
     // AMATEURSHOW ERROR
     AMATEURSHOW_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURSHOW4000", "존재하지 않는 소극장 공연입니다."),
 
     // MUSICAL ERROR
     MUSICAL_NOT_FOUND(HttpStatus.NOT_FOUND, "MUSICAL4000", "존재하지 않는 뮤지컬입니다."),
 
-    // MUSICAL ERROR
-    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT4000", "이벤트가 존재하지 않는 뮤지컬이므로 추가할 수 없습니다."),
-    EVENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "EVENT4001", "이벤트가 이미 존재하는 뮤지컬입니다.");
+    // INQUIRY ERROR
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY4000", "존재하지 않는 문의글입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/muit/backend/controller/adminController/ManageInquiryController.java
+++ b/src/main/java/muit/backend/controller/adminController/ManageInquiryController.java
@@ -1,0 +1,49 @@
+package muit.backend.controller.adminController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.ApiResponse;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseRequestDTO;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseResponseDTO;
+import muit.backend.dto.adminDTO.manageInquiryDTO.ManageInquiryResponseDTO;
+import muit.backend.service.adminService.InquiryResponseService;
+import muit.backend.service.adminService.ManageInquiryService;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+
+@Tag(name = "어드민이 문의 관리")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/inquiries")
+public class ManageInquiryController {
+
+    private final ManageInquiryService manageInquiryService;
+    private final InquiryResponseService inquiryResponseService;
+
+    @Operation(summary = "전체 문의 내역 조회")
+    @GetMapping
+    public ApiResponse<Page<ManageInquiryResponseDTO.ManageInquiryResultListDTO>> getAllInquiries(@ParameterObject Pageable pageable,
+                                                                                                  @RequestParam(required = false) String keyword,
+                                                                                                  @RequestParam(required = false) Set<String> selectedFields) {
+
+        Page<ManageInquiryResponseDTO.ManageInquiryResultListDTO> inquires = manageInquiryService.getAllInquiries(pageable, keyword, selectedFields);
+        return ApiResponse.onSuccess(inquires);
+    }
+
+    @Operation(summary = "특정 문의 상세 조회")
+    @GetMapping("/{inquiryId}")
+    public ApiResponse<ManageInquiryResponseDTO.ManageInquiryResultDTO> getInquiry(@PathVariable("inquiryId") Long inquiryId) {
+        return ApiResponse.onSuccess(manageInquiryService.getInquiry(inquiryId));
+    }
+
+    @Operation(summary = "특정 문의 답변 생성/수정")
+    @PutMapping("/response/{inquiryId}")
+    public ApiResponse<InquiryResponseResponseDTO.InquiryResponseUpsertDTO> upsertResponse(@PathVariable("inquiryId") Long inquiryId, @RequestBody InquiryResponseRequestDTO.InquiryResponseUpsertDTO requestDTO) {
+        return ApiResponse.onSuccess(inquiryResponseService.upsertResponse(inquiryId, requestDTO));
+    }
+}

--- a/src/main/java/muit/backend/converter/adminConverter/InquiryResponseConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/InquiryResponseConverter.java
@@ -1,0 +1,26 @@
+package muit.backend.converter.adminConverter;
+
+import muit.backend.domain.entity.member.Inquiry;
+import muit.backend.domain.entity.member.InquiryResponse;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseRequestDTO;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseResponseDTO;
+
+public class InquiryResponseConverter {
+
+    public static InquiryResponseResponseDTO.InquiryResponseUpsertDTO toInquiryResponseUpsertDTO(InquiryResponse inquiryResponse) {
+        return InquiryResponseResponseDTO.InquiryResponseUpsertDTO.builder()
+                .inquiryId(inquiryResponse.getInquiry().getId())
+                .responseId(inquiryResponse.getId())
+                .content(inquiryResponse.getContent())
+                .createdAt(inquiryResponse.getCreatedAt())
+                .build();
+
+    }
+
+    public static InquiryResponse toInquiryResponse(Inquiry inquiry, InquiryResponseRequestDTO.InquiryResponseUpsertDTO requestDTO) {
+        return InquiryResponse.builder()
+                .inquiry(inquiry)
+                .content(requestDTO.getContent())
+                .build();
+    }
+}

--- a/src/main/java/muit/backend/converter/adminConverter/ManageInquiryConverter.java
+++ b/src/main/java/muit/backend/converter/adminConverter/ManageInquiryConverter.java
@@ -1,0 +1,75 @@
+package muit.backend.converter.adminConverter;
+
+import muit.backend.domain.entity.member.Inquiry;
+import muit.backend.dto.adminDTO.manageInquiryDTO.ManageInquiryResponseDTO;
+
+import java.util.Set;
+
+public class ManageInquiryConverter {
+
+    public static ManageInquiryResponseDTO.ManageInquiryResultListDTO toManageInquiryResultListDTO(Inquiry inquiry, Set<String> selectedFields, boolean isKeywordSearch) {
+
+        // 키워드 검색이거나 전체 조회인 경우 모든 필드 포함
+        if (isKeywordSearch || selectedFields == null || selectedFields.isEmpty()) {
+            return ManageInquiryResponseDTO.ManageInquiryResultListDTO.builder()
+                    .inquiryId(inquiry.getId())
+                    .memberId(inquiry.getMember().getId())
+                    .userName(inquiry.getMember().getUsername())
+                    .memberName(inquiry.getMember().getName())
+                    .email(inquiry.getMember().getEmail())
+                    .phone(inquiry.getMember().getPhone())
+                    .createdAt(inquiry.getCreatedAt())
+                    .inquiryStatus(inquiry.getInquiryStatus())
+                    .build();
+        }
+
+        // selectedFields로 특정 필드만 선택한 경우
+        return ManageInquiryResponseDTO.ManageInquiryResultListDTO.builder()
+                .inquiryId(inquiry.getId())  // ID는 항상 포함
+                .userName(selectedFields.contains("userName") ? inquiry.getMember().getUsername() : null)
+                .memberName(selectedFields.contains("memberName") ? inquiry.getMember().getName() : null)
+                .email(selectedFields.contains("email") ? inquiry.getMember().getEmail() : null)
+                .phone(selectedFields.contains("phone") ? inquiry.getMember().getPhone() : null)
+                .createdAt(selectedFields.contains("createdAt") ? inquiry.getCreatedAt() : null)
+                .inquiryStatus(selectedFields.contains("inquiryStatus") ? inquiry.getInquiryStatus() : null)
+                .build();
+    }
+
+
+    public static ManageInquiryResponseDTO.ManageInquiryResultDTO toManageInquiryResultDTO(Inquiry inquiry) {
+
+        // Member 정보
+        ManageInquiryResponseDTO.Member memberInfo = ManageInquiryResponseDTO.Member.builder()
+                .memberId(inquiry.getMember().getId())
+                .memberName(inquiry.getMember().getName())
+                .email(inquiry.getMember().getEmail())
+                .phone(inquiry.getMember().getPhone())
+                .build();
+
+        // Inquiry 정보
+        ManageInquiryResponseDTO.Inquiry inquiryInfo = ManageInquiryResponseDTO.Inquiry.builder()
+                .inquiryId(inquiry.getId())
+                .createdAt(inquiry.getCreatedAt())
+                .status(inquiry.getInquiryStatus())
+                .title(inquiry.getTitle())
+                .content(inquiry.getContent())
+                .build();
+
+        // Response 정보
+        ManageInquiryResponseDTO.Response responseInfo = new ManageInquiryResponseDTO.Response();
+
+        if (inquiry.getInquiryResponse() != null) { // 답변 있을 때
+            responseInfo = ManageInquiryResponseDTO.Response.builder()
+                    .responseId(inquiry.getInquiryResponse().getId())
+                    .content(inquiry.getInquiryResponse().getContent())
+                    .createdAt(inquiry.getInquiryResponse().getCreatedAt())
+                    .build();
+        }
+
+        return ManageInquiryResponseDTO.ManageInquiryResultDTO.builder()
+                .member(memberInfo)
+                .inquiry(inquiryInfo)
+                .response(responseInfo)
+                .build();
+    }
+}

--- a/src/main/java/muit/backend/domain/entity/member/Inquiry.java
+++ b/src/main/java/muit/backend/domain/entity/member/Inquiry.java
@@ -3,6 +3,7 @@ package muit.backend.domain.entity.member;
 import jakarta.persistence.*;
 import lombok.*;
 import muit.backend.domain.common.BaseEntity;
+import muit.backend.domain.entity.amateur.AmateurSummary;
 import muit.backend.domain.enums.InquiryStatus;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -10,12 +11,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @Builder
+@Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Inquiry extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String title;
@@ -26,12 +29,15 @@ public class Inquiry extends BaseEntity {
     @ColumnDefault("'AWAIT'")
     private InquiryStatus inquiryStatus;
 
-
-    @OneToMany(mappedBy = "inquiry", cascade = CascadeType.ALL)
-    private List<InquiryResponse> inquiryResponseList = new ArrayList<>();
+    @OneToOne(mappedBy = "inquiry", cascade = CascadeType.ALL)
+    private InquiryResponse inquiryResponse;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
+    // 답변 추가되면 상태 변경
+    public void addResponse(InquiryResponse response) {
+        this.inquiryStatus = InquiryStatus.COMPLETED;
+    }
 }

--- a/src/main/java/muit/backend/domain/entity/member/InquiryResponse.java
+++ b/src/main/java/muit/backend/domain/entity/member/InquiryResponse.java
@@ -6,19 +6,26 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muit.backend.domain.common.BaseEntity;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseRequestDTO;
 
 @Entity
-@Getter @Builder
+@Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class InquiryResponse extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "inquiry_id")
     private Inquiry inquiry;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/muit/backend/dto/adminDTO/inquiryResponseDTO/InquiryResponseRequestDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/inquiryResponseDTO/InquiryResponseRequestDTO.java
@@ -1,0 +1,17 @@
+package muit.backend.dto.adminDTO.inquiryResponseDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class InquiryResponseRequestDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InquiryResponseUpsertDTO {
+        private String content;
+    }
+}

--- a/src/main/java/muit/backend/dto/adminDTO/inquiryResponseDTO/InquiryResponseResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/inquiryResponseDTO/InquiryResponseResponseDTO.java
@@ -1,0 +1,22 @@
+package muit.backend.dto.adminDTO.inquiryResponseDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class InquiryResponseResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class InquiryResponseUpsertDTO { // 답변 생성
+        private Long inquiryId;
+        private Long responseId;
+        private String content;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/muit/backend/dto/adminDTO/manageInquiryDTO/ManageInquiryResponseDTO.java
+++ b/src/main/java/muit/backend/dto/adminDTO/manageInquiryDTO/ManageInquiryResponseDTO.java
@@ -1,0 +1,74 @@
+package muit.backend.dto.adminDTO.manageInquiryDTO;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import muit.backend.domain.enums.InquiryStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ManageInquiryResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ManageInquiryResultListDTO { // 문의 관리 내역 전체 조회
+        private Long inquiryId; // 문의 id
+        private Long memberId; // 등록자 id
+        private String userName; // 문의 등록자 아이디
+        private String memberName; // 문의 등록자명
+        private String email; // 등록자 이메일
+        private String phone; // 등록자 전번
+        private LocalDateTime createdAt;
+        private InquiryStatus inquiryStatus; // 진행도 (미완료, 완료)
+    }
+
+    // === 특정 문의글 조회 ===
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ManageInquiryResultDTO {
+        private Member member;
+        private Inquiry inquiry;
+        private Response response;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Member {
+        private Long memberId;
+        private String memberName;
+        private String email;
+        private String phone;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Inquiry {
+        private Long inquiryId;
+        private LocalDateTime createdAt;
+        private InquiryStatus status;
+        private String title;
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+        private Long responseId;
+        private String content;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/muit/backend/repository/InquiryRepository.java
+++ b/src/main/java/muit/backend/repository/InquiryRepository.java
@@ -1,0 +1,35 @@
+package muit.backend.repository;
+
+import muit.backend.domain.entity.member.Inquiry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+
+    // 전체 조회용 (member 함께 조회)
+    @Query("SELECT i FROM Inquiry i JOIN FETCH i.member ORDER BY i.createdAt DESC")
+    Page<Inquiry> findAllWithMember(Pageable pageable);
+
+    // 검색어가 있을 때
+    @Query("SELECT i FROM Inquiry i JOIN FETCH i.member WHERE " +
+            "i.member.username LIKE %:keyword% " +
+            "OR i.member.name LIKE %:keyword% " +
+            "OR i.member.email LIKE %:keyword% " +
+            "OR i.member.phone LIKE %:keyword% " +
+            "ORDER BY i.createdAt DESC")
+    Page<Inquiry> findByKeyword(Pageable pageable, @Param("keyword") String keyword);
+
+    // 특정 문의 조회용 (member 함께 조회)
+    @Query("SELECT DISTINCT i FROM Inquiry i " +
+            "JOIN FETCH i.member " +
+            "LEFT JOIN FETCH i.inquiryResponse " +  // 답변은 항상 존재하지 X -> LEFT JOIN 사용
+            "WHERE i.id = :inquiryId")
+    Optional<Inquiry> findByIdWithMemberAndResponse(@Param("inquiryId") Long inquiryId);
+}

--- a/src/main/java/muit/backend/repository/InquiryResponseRepository.java
+++ b/src/main/java/muit/backend/repository/InquiryResponseRepository.java
@@ -1,0 +1,10 @@
+package muit.backend.repository;
+
+import muit.backend.domain.entity.member.InquiryResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InquiryResponseRepository extends JpaRepository<InquiryResponse, Long> {
+
+}

--- a/src/main/java/muit/backend/service/adminService/InquiryResponseService.java
+++ b/src/main/java/muit/backend/service/adminService/InquiryResponseService.java
@@ -1,0 +1,11 @@
+package muit.backend.service.adminService;
+
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseRequestDTO;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseResponseDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface InquiryResponseService {
+
+    public InquiryResponseResponseDTO.InquiryResponseUpsertDTO upsertResponse(Long inquiryId, InquiryResponseRequestDTO.InquiryResponseUpsertDTO requestDTO);
+}

--- a/src/main/java/muit/backend/service/adminService/InquiryResponseServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/InquiryResponseServiceImpl.java
@@ -1,0 +1,47 @@
+package muit.backend.service.adminService;
+
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.code.status.ErrorStatus;
+import muit.backend.apiPayLoad.exception.GeneralException;
+import muit.backend.converter.adminConverter.InquiryResponseConverter;
+import muit.backend.domain.entity.member.Inquiry;
+import muit.backend.domain.entity.member.InquiryResponse;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseRequestDTO;
+import muit.backend.dto.adminDTO.inquiryResponseDTO.InquiryResponseResponseDTO;
+import muit.backend.repository.InquiryRepository;
+import muit.backend.repository.InquiryResponseRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InquiryResponseServiceImpl implements InquiryResponseService {
+
+    private final InquiryRepository inquiryRepository;
+    private final InquiryResponseRepository inquiryResponseRepository;
+
+    // 답변 생성
+    @Override
+    @Transactional
+    public InquiryResponseResponseDTO.InquiryResponseUpsertDTO upsertResponse(Long inquiryId, InquiryResponseRequestDTO.InquiryResponseUpsertDTO requestDTO) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.INQUIRY_NOT_FOUND));
+
+        InquiryResponse inquiryResponse;
+
+        if (inquiry.getInquiryResponse() != null) {
+            // 기존 답변이 있으면 수정하기
+            inquiryResponse = inquiry.getInquiryResponse();
+            inquiryResponse.updateContent(requestDTO.getContent());
+        } else {
+            // 답변이 없으면 생성하기
+            inquiryResponse = InquiryResponseConverter.toInquiryResponse(inquiry, requestDTO);
+            inquiryResponse = inquiryResponseRepository.save(inquiryResponse);
+
+            inquiry.addResponse(inquiryResponse);  // 답변 추가됨 -> 상태 변경 호출
+        }
+
+        return InquiryResponseConverter.toInquiryResponseUpsertDTO(inquiryResponse);
+    }
+}

--- a/src/main/java/muit/backend/service/adminService/ManageInquiryService.java
+++ b/src/main/java/muit/backend/service/adminService/ManageInquiryService.java
@@ -1,0 +1,17 @@
+package muit.backend.service.adminService;
+
+import muit.backend.dto.adminDTO.manageInquiryDTO.ManageInquiryResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+public interface ManageInquiryService {
+    public Page<ManageInquiryResponseDTO.ManageInquiryResultListDTO> getAllInquiries(Pageable pageable, String keyword, Set<String> selectedFields);
+
+    public ManageInquiryResponseDTO.ManageInquiryResultDTO getInquiry(Long inquiryId);
+
+
+}

--- a/src/main/java/muit/backend/service/adminService/ManageInquiryServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/ManageInquiryServiceImpl.java
@@ -1,0 +1,57 @@
+package muit.backend.service.adminService;
+
+import lombok.RequiredArgsConstructor;
+import muit.backend.apiPayLoad.code.status.ErrorStatus;
+import muit.backend.apiPayLoad.exception.GeneralException;
+import muit.backend.converter.adminConverter.ManageInquiryConverter;
+import muit.backend.domain.entity.member.Inquiry;
+import muit.backend.dto.adminDTO.manageInquiryDTO.ManageInquiryResponseDTO;
+import muit.backend.repository.InquiryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManageInquiryServiceImpl implements ManageInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    // 문의 내역 전체 조회
+    @Override
+    public Page<ManageInquiryResponseDTO.ManageInquiryResultListDTO> getAllInquiries(Pageable pageable, String keyword, Set<String> selectedFields) {
+
+        // 검색어가 있는지 확인
+        boolean isKeywordSearch = keyword != null && !keyword.trim().isEmpty(); // 그냥 빈 검색어도 없다고 침
+
+        Page<Inquiry> inquiries;
+
+        // 검색어가 있으면 해당 키워드로 검색
+        if (isKeywordSearch) {
+            inquiries = inquiryRepository.findByKeyword(pageable, keyword);
+            if (inquiries.isEmpty()) {
+                return Page.empty(pageable);
+            }
+        } else { // 검색어가 없으면 모든 소극장 공연 정보 조회
+            inquiries = inquiryRepository.findAllWithMember(pageable);
+        }
+
+        return inquiries.map(inquiry ->
+                ManageInquiryConverter.toManageInquiryResultListDTO(inquiry, selectedFields, isKeywordSearch)
+        );
+    }
+
+    // 특정 문의 상세 조회
+    @Override
+    public ManageInquiryResponseDTO.ManageInquiryResultDTO getInquiry(Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findByIdWithMemberAndResponse(inquiryId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.INQUIRY_NOT_FOUND));
+
+        return ManageInquiryConverter.toManageInquiryResultDTO(inquiry);
+    }
+
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 어드민이 문의 관리하는 api 구현했습니다.
- 문의글 하나에 답변도 하나씩만 달 수 있다고 해서 엔티티 연관관계 수정했습니다.
- 버튼이 "답변/수정하기"로 되어있어서, 하나의 엔드포인트를 사용하되 upsert 형태로, 답변이 이미 있으면 수정, 없으면 생성하는 방식으로 구현했습니다.
- 어드민이 문의내역 전체 조회, 특정 문의 상세 조회, 답변 생성/수정하는 api 만들었습니다.

  <br/>

## 🔧 Todo

- 어드민 페이지 전부 다 토큰 받도록 수정해야 합니다.
