### PR TITLE
[fix] 어드민이 소극장 공연 등록/반려

### DIFF
--- a/src/main/java/muit/backend/controller/adminController/ManageAmateurShowController.java
+++ b/src/main/java/muit/backend/controller/adminController/ManageAmateurShowController.java
@@ -48,10 +48,16 @@ public class ManageAmateurShowController {
     }
 
     @Operation(summary = "소극장 공연 최종 등록/반려")
-    @PatchMapping("/{amateurShowId}/decision")
+    @PutMapping("/{amateurShowId}/decision")
     public ApiResponse<ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO> decideAmateurShow(@PathVariable("amateurShowId") Long amateurShowId, @RequestParam AmateurStatus amateurStatus, @RequestBody ManageAmateurShowRequestDTO.ManageAmateurShowDecideDTO requestDTO) {
         ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO amateurShow = manageAmateurShowService.decideAmateurShow(amateurShowId, amateurStatus, requestDTO);
         return ApiResponse.onSuccess(amateurShow);
+    }
+
+    @Operation(summary = "소극장 공연 등록/반려 조회", description = "특정 소극장 공연 등록/반려 페이지 조회")
+    @GetMapping("/{amateurShowId}/decision")
+    public ApiResponse<ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO> getDecideAmateurShow(@PathVariable("amateurShowId") Long amateurShowId) {
+        return ApiResponse.onSuccess(manageAmateurShowService.getDecideAmateurShow(amateurShowId));
     }
 
 }

--- a/src/main/java/muit/backend/domain/entity/amateur/AmateurShow.java
+++ b/src/main/java/muit/backend/domain/entity/amateur/AmateurShow.java
@@ -99,20 +99,6 @@ public class AmateurShow extends BaseEntity {
         }
     }
 
-    public void decideAmateurShow(AmateurStatus amateurStatus, ManageAmateurShowRequestDTO.ManageAmateurShowDecideDTO requestDTO) {
-
-        // 상태 업데이트 (등록/반려)
-        this.amateurStatus = amateurStatus;
-
-        // AGAIN일 때만 반려 사유 설정 (필수는 아님)
-        if (amateurStatus == AmateurStatus.AGAIN) {
-            this.rejectReason = requestDTO.getRejectReason();
-        } else if (amateurStatus == AmateurStatus.YET || amateurStatus == AmateurStatus.APPROVED) {
-            this.rejectReason = null;  // APPROVED일 때는 명시적으로 null 설정
-        }
-
-    }
-
     public void updateAmateurTicket(AmateurTicketRequestDTO.AmateurTicketUpdateDTO requestDTO) {
         if (requestDTO.getName() != null) {
             this.name = requestDTO.getName();
@@ -128,4 +114,15 @@ public class AmateurShow extends BaseEntity {
         }
     }
 
+    public void updateRejectReason(String rejectReason) {
+        this.rejectReason = rejectReason;
+    }
+
+    public void createRejectReason(String rejectReason) {
+        this.rejectReason = rejectReason;
+    }
+
+    public void updateAmateurStatus(AmateurStatus amateurStatus) {
+        this.amateurStatus = amateurStatus;
+    }
 }

--- a/src/main/java/muit/backend/service/adminService/ManageAmateurShowService.java
+++ b/src/main/java/muit/backend/service/adminService/ManageAmateurShowService.java
@@ -20,4 +20,6 @@ public interface ManageAmateurShowService {
     public ManageAmateurShowResponseDTO.ManageAmateurShowResultDTO updateAmateurShow(Long amateurShowId, ManageAmateurShowRequestDTO.ManageAmateurShowUpdateDTO requestDTO);
 
     public ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO decideAmateurShow(Long amateurShowId, @NotNull AmateurStatus amateurStatus, ManageAmateurShowRequestDTO.ManageAmateurShowDecideDTO requestDTO);
+
+    public ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO getDecideAmateurShow(Long amateurShowId);
 }

--- a/src/main/java/muit/backend/service/adminService/ManageAmateurShowServiceImpl.java
+++ b/src/main/java/muit/backend/service/adminService/ManageAmateurShowServiceImpl.java
@@ -76,7 +76,30 @@ public class ManageAmateurShowServiceImpl implements ManageAmateurShowService {
         AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
 
-        amateurShow.decideAmateurShow(amateurStatus, requestDTO);
+
+        if (amateurStatus == AmateurStatus.AGAIN) {
+            if (amateurShow.getRejectReason() != null) {
+                // 기존 반려 사유가 있으면 수정
+                amateurShow.updateRejectReason(requestDTO.getRejectReason());
+            } else {
+                // 반려 사유가 없으면 생성
+                amateurShow.createRejectReason(requestDTO.getRejectReason());
+            }
+        } else if (amateurStatus == AmateurStatus.YET || amateurStatus == AmateurStatus.APPROVED) {
+            amateurShow.createRejectReason(null); // 다른 상태일 때는 반려 사유 null로 설정
+        }
+
+        amateurShow.updateAmateurStatus(amateurStatus);
+
+        return ManageAmateurShowConverter.toManageAmateurShowDecideDTO(amateurShow);
+    }
+
+    // 소극장 공연 등록/반려 조회
+    @Override
+    public ManageAmateurShowResponseDTO.ManageAmateurShowDecideDTO getDecideAmateurShow(Long amateurShowId) {
+        AmateurShow amateurShow = amateurShowRepository.findById(amateurShowId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AMATEURSHOW_NOT_FOUND));
+
         return ManageAmateurShowConverter.toManageAmateurShowDecideDTO(amateurShow);
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 어드민이 소극장 공연 등록/반려하는 로직 수정했습니다.
- 반려사유가 없으면 생성, 있으면 수정하는 방식입니다. 상태가 YET, APPROVED라면 반려사유를 입력해도 null로 들어가게 했습니다.
- 등록/반려 페이지 조회 api 안 만들었어서 추가했습니다.
