### PR TITLE
[feat]  report post and comment feature created

### DIFF
--- a/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -44,6 +44,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //COMMENT ERROR
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4000", "존재하지 않는 댓글입니다."),
+    UNSUPPORTED_COMMENT_TYPE(HttpStatus.BAD_REQUEST, "COMMENT4001", "지원하지 않는 댓글 유형입니다."),
 
     // AMATEURSHOW ERROR
     AMATEURSHOW_NOT_FOUND(HttpStatus.NOT_FOUND, "AMATEURSHOW4000", "존재하지 않는 소극장 공연입니다."),

--- a/src/main/java/muit/backend/controller/CommentController.java
+++ b/src/main/java/muit/backend/controller/CommentController.java
@@ -12,6 +12,8 @@ import muit.backend.dto.commentDTO.CommentReplyRequestDTO;
 import muit.backend.dto.commentDTO.CommentReplyResponseDTO;
 import muit.backend.dto.postDTO.LostRequestDTO;
 import muit.backend.dto.postDTO.LostResponseDTO;
+import muit.backend.dto.reportDTO.ReportRequestDTO;
+import muit.backend.dto.reportDTO.ReportResponseDTO;
 import muit.backend.service.CommentService;
 import muit.backend.service.MemberService;
 import org.springframework.web.bind.annotation.*;
@@ -62,5 +64,20 @@ public class CommentController {
 
         Member member = memberService.getMemberByToken(accessToken);
         return ApiResponse.onSuccess(commentService.deleteComment(commentType,commentId,member));
+    }
+
+    @PostMapping("/report/{commentId}")
+    @Operation(summary = "댓글/대댓글 신고 API")
+    @Parameters({
+            @Parameter(name = "commentType", description = "COMMENT/REPLY 중 하나로 보내주세요"),
+            @Parameter(name = "commentId", description = "신고하려는 댓글/대댓글의 아이디를 주세요")
+    })
+    public ApiResponse<ReportResponseDTO.ReportResultDTO> reportComment(@RequestHeader("Authorization") String accessToken,
+                                                                        @RequestParam(value = "commentType", required = true) String commentType,
+                                                                        @PathVariable("commentId") Long commentId,
+                                                                        @RequestBody ReportRequestDTO requestDTO) {
+
+        Member member = memberService.getMemberByToken(accessToken);
+        return ApiResponse.onSuccess(commentService.reportComment(commentType,commentId,member,requestDTO));
     }
 }

--- a/src/main/java/muit/backend/controller/postController/CommonPostController.java
+++ b/src/main/java/muit/backend/controller/postController/CommonPostController.java
@@ -10,6 +10,8 @@ import muit.backend.domain.entity.member.Member;
 import muit.backend.domain.entity.member.Post;
 import muit.backend.domain.enums.PostType;
 import muit.backend.dto.postDTO.PostResponseDTO;
+import muit.backend.dto.reportDTO.ReportRequestDTO;
+import muit.backend.dto.reportDTO.ReportResponseDTO;
 import muit.backend.service.MemberService;
 import muit.backend.service.postService.PostService;
 import org.springframework.web.bind.annotation.*;
@@ -37,6 +39,17 @@ public class CommonPostController {
                                                                    @PathVariable("postId") Long postId) {
         Member member = memberService.getMemberByToken(accessToken);
         return ApiResponse.onSuccess(postService.deletePost(postId, member));
+    }
+
+    @PostMapping("/report/{postId}")
+    @Operation(summary = "게시글 신고 API", description = "게시글을 신고할 수 있는 API입니다.")
+    public ApiResponse<ReportResponseDTO.ReportResultDTO> reportPost(@RequestHeader("Authorization") String accessToken,
+                                                     @RequestBody ReportRequestDTO requestDTO,
+                                                     @PathVariable Long postId) {
+
+        Member member = memberService.getMemberByToken(accessToken);
+        return ApiResponse.onSuccess(postService.reportPost(postId, member,requestDTO));
+
     }
 
 }

--- a/src/main/java/muit/backend/domain/entity/member/Comment.java
+++ b/src/main/java/muit/backend/domain/entity/member/Comment.java
@@ -40,6 +40,11 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<Report> reportList = new ArrayList<>();
+
+
+
     public void deleteContent(String newContent) {
         this.content = newContent;
     }

--- a/src/main/java/muit/backend/domain/entity/member/Reply.java
+++ b/src/main/java/muit/backend/domain/entity/member/Reply.java
@@ -8,6 +8,9 @@ import lombok.NoArgsConstructor;
 import muit.backend.domain.common.BaseEntity;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -32,4 +35,7 @@ public class Reply extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
+
+    @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL)
+    private List<Report> reportList = new ArrayList<>();
 }

--- a/src/main/java/muit/backend/domain/entity/member/Report.java
+++ b/src/main/java/muit/backend/domain/entity/member/Report.java
@@ -27,4 +27,14 @@ public class Report extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+
 }

--- a/src/main/java/muit/backend/dto/reportDTO/ReportRequestDTO.java
+++ b/src/main/java/muit/backend/dto/reportDTO/ReportRequestDTO.java
@@ -1,0 +1,9 @@
+package muit.backend.dto.reportDTO;
+
+import lombok.Getter;
+
+@Getter
+public class ReportRequestDTO {
+    private String content;
+    private Long memberId;
+}

--- a/src/main/java/muit/backend/dto/reportDTO/ReportResponseDTO.java
+++ b/src/main/java/muit/backend/dto/reportDTO/ReportResponseDTO.java
@@ -1,0 +1,32 @@
+package muit.backend.dto.reportDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+public class ReportResponseDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportResultDTO {
+        private Long id;
+        private String message;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GeneralReportDTO {
+        private Long id;
+        private String content;
+        private Long postId;
+        private LocalDateTime createdAt;
+        private Long memberId;
+    }
+}

--- a/src/main/java/muit/backend/repository/ReportRepository.java
+++ b/src/main/java/muit/backend/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package muit.backend.repository;
+
+import muit.backend.domain.entity.member.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Integer> {
+}

--- a/src/main/java/muit/backend/service/CommentService.java
+++ b/src/main/java/muit/backend/service/CommentService.java
@@ -3,6 +3,8 @@ package muit.backend.service;
 import muit.backend.domain.entity.member.Member;
 import muit.backend.dto.commentDTO.CommentReplyRequestDTO;
 import muit.backend.dto.commentDTO.CommentReplyResponseDTO;
+import muit.backend.dto.reportDTO.ReportRequestDTO;
+import muit.backend.dto.reportDTO.ReportResponseDTO;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +16,7 @@ public interface CommentService {
     CommentReplyResponseDTO.ReplyResponseDTO writeReply(CommentReplyRequestDTO.ReplyRequestDTO requestDTO, Long commentId, Member member);
 
     CommentReplyResponseDTO.DeleteResultDTO deleteComment(String commentType, Long commentId, Member member);
+
+    ReportResponseDTO.ReportResultDTO reportComment(String commentType, Long commentId, Member member, ReportRequestDTO requestDTO);
 }
 

--- a/src/main/java/muit/backend/service/CommentServiceImpl.java
+++ b/src/main/java/muit/backend/service/CommentServiceImpl.java
@@ -6,16 +6,12 @@ import muit.backend.apiPayLoad.exception.GeneralException;
 import muit.backend.apiPayLoad.code.status.ErrorStatus;
 import muit.backend.apiPayLoad.exception.GeneralException;
 import muit.backend.converter.CommentConverter;
-import muit.backend.domain.entity.member.Comment;
-import muit.backend.domain.entity.member.Member;
-import muit.backend.domain.entity.member.Post;
-import muit.backend.domain.entity.member.Reply;
+import muit.backend.domain.entity.member.*;
 import muit.backend.dto.commentDTO.CommentReplyRequestDTO;
 import muit.backend.dto.commentDTO.CommentReplyResponseDTO;
-import muit.backend.repository.CommentRepository;
-import muit.backend.repository.MemberRepository;
-import muit.backend.repository.PostRepository;
-import muit.backend.repository.ReplyRepository;
+import muit.backend.dto.reportDTO.ReportRequestDTO;
+import muit.backend.dto.reportDTO.ReportResponseDTO;
+import muit.backend.repository.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -30,6 +26,7 @@ public class CommentServiceImpl implements CommentService {
     private final ReplyRepository replyRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final ReportRepository reportRepository;
 
 
     //특정 게시물의 모든 댓글 조회
@@ -101,6 +98,25 @@ public class CommentServiceImpl implements CommentService {
 
         return CommentReplyResponseDTO.DeleteResultDTO.builder()
                 .message("댓글이 성공적으로 삭제되었습니다.").build();
+    }
+
+    @Override
+    public ReportResponseDTO.ReportResultDTO reportComment(String commentType, Long commentId, Member member, ReportRequestDTO requestDTO) {
+
+        Report report;
+        if(commentType.equals("COMMENT")){
+            Comment comment = commentRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+            report = Report.builder().comment(comment).content(requestDTO.getContent()).build();
+        }else if(commentType.equals("REPLY")){
+            Reply reply = replyRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+            report = Report.builder().reply(reply).content(requestDTO.getContent()).build();
+        }else{
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_COMMENT_TYPE);
+        }
+
+        Report saved = reportRepository.save(report);
+
+        return ReportResponseDTO.ReportResultDTO.builder().id(saved.getId()).message("정상적으로 신고 처리 되었습니다.").build();
     }
 
 }

--- a/src/main/java/muit/backend/service/postService/PostService.java
+++ b/src/main/java/muit/backend/service/postService/PostService.java
@@ -4,6 +4,8 @@ import muit.backend.domain.entity.member.Member;
 import muit.backend.domain.enums.PostType;
 import muit.backend.dto.postDTO.PostRequestDTO;
 import muit.backend.dto.postDTO.PostResponseDTO;
+import muit.backend.dto.reportDTO.ReportRequestDTO;
+import muit.backend.dto.reportDTO.ReportResponseDTO;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,4 +31,7 @@ public interface PostService {
     public PostResponseDTO.GeneralPostResponseDTO editPost(Long postId, PostRequestDTO postRequestDTO, List<MultipartFile> img, Member member);
 
     PostResponseDTO.likeResultDTO likePost(Long postId, Member member);
+
+    ReportResponseDTO.ReportResultDTO reportPost(Long postId, Member member, ReportRequestDTO requestDTO);
+
 }

--- a/src/main/java/muit/backend/service/postService/PostServiceImpl.java
+++ b/src/main/java/muit/backend/service/postService/PostServiceImpl.java
@@ -7,9 +7,12 @@ import muit.backend.converter.postConverter.PostConverter;
 import muit.backend.domain.entity.member.Member;
 import muit.backend.domain.entity.member.Post;
 import muit.backend.domain.entity.member.PostLikes;
+import muit.backend.domain.entity.member.Report;
 import muit.backend.domain.enums.PostType;
 import muit.backend.dto.postDTO.PostRequestDTO;
 import muit.backend.dto.postDTO.PostResponseDTO;
+import muit.backend.dto.reportDTO.ReportRequestDTO;
+import muit.backend.dto.reportDTO.ReportResponseDTO;
 import muit.backend.repository.*;
 import muit.backend.s3.FilePath;
 import muit.backend.s3.UuidFile;
@@ -32,8 +35,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final PostLikesRepository postLikesRepository;
     private final UuidFileService uuidFileService;
-    private final ReplyRepository replyRepository;
-    private final CommentService commentService;
+    private final ReportRepository reportRepository;
 
     //게시글 작성
     @Override
@@ -185,5 +187,13 @@ public class PostServiceImpl implements PostService {
             isLiked = false;
         }
         return PostResponseDTO.likeResultDTO.builder().isLiked(isLiked).build();
+    }
+
+    @Override
+    public ReportResponseDTO.ReportResultDTO reportPost(Long postId, Member member, ReportRequestDTO requestDTO) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+        Report report = Report.builder().content(requestDTO.getContent()).member(member).post(post).build();
+        Report saved = reportRepository.save(report);
+        return ReportResponseDTO.ReportResultDTO.builder().id(saved.getId()).message("신고가 정상적으로 접수되었습니다.").build();
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 게시글과 댓글 신고 기능 추가합니다
- PM과 상의 결과 댓글도 신고 가능하게 구현했습니다
- 위의 이유로 report 엔티티 연관관계를 post, comment, reply 모두 다 가지도록 수정했습니다

  <br/>

## 🔧 Todo

- 관리자의 신고 수 확인, 게시글/댓글 삭제 기능 중 필요한 것 추가 구현 예정

