### PR TITLE
[fix] Query String null case fixing

### DIFF
--- a/src/main/java/muit/backend/controller/postController/LostController.java
+++ b/src/main/java/muit/backend/controller/postController/LostController.java
@@ -75,10 +75,10 @@ public class LostController {
         };
         memberService.getMemberByToken(accessToken);
         Map<String,String> search = new HashMap<>();
-        search.put("musicalName",musicalName);
-        search.put("lostDate",lostDate.toString());
-        search.put("location",location);
-        search.put("lostItem",lostItem);
+        search.put("musicalName",musicalName.trim());
+        search.put("lostDate",lostDate!=null ? lostDate.toString().trim():"");
+        search.put("location",location.trim());
+        search.put("lostItem",lostItem.trim());
 
         return ApiResponse.onSuccess(lostService.getLostPostList(postType, page, size, search));
     }


### PR DESCRIPTION
## 🔎 작업 내용

- 쿼리에서 lostDate값이 null 일때 toString 바로 적용되어 일어나는 오류 고쳤습니다