### PR TITLE
[feat] report get API created

### DIFF
--- a/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/muit/backend/apiPayLoad/code/status/ErrorStatus.java
@@ -41,6 +41,9 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_TICKET_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "MEMBERTICKET4003", "이미 취소하신 티켓입니다."),
     //POST ERROR
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4000", "존재하지 않는 게시글입니다."),
+    
+    //REPORT ERROR
+    UNSUPPORTED_OBJECT_TYPE(HttpStatus.BAD_REQUEST, "REPORT4000", "지원하지 않는 신고 타입입니다."),
 
     //COMMENT ERROR
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4000", "존재하지 않는 댓글입니다."),

--- a/src/main/java/muit/backend/controller/postController/CommonPostController.java
+++ b/src/main/java/muit/backend/controller/postController/CommonPostController.java
@@ -6,15 +6,28 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import muit.backend.apiPayLoad.ApiResponse;
+import muit.backend.apiPayLoad.code.status.ErrorStatus;
+import muit.backend.apiPayLoad.exception.GeneralException;
 import muit.backend.domain.entity.member.Member;
 import muit.backend.domain.entity.member.Post;
+import muit.backend.domain.entity.member.Report;
 import muit.backend.domain.enums.PostType;
+import muit.backend.domain.enums.ReportObjectType;
+import muit.backend.domain.enums.Role;
 import muit.backend.dto.postDTO.PostResponseDTO;
 import muit.backend.dto.reportDTO.ReportRequestDTO;
 import muit.backend.dto.reportDTO.ReportResponseDTO;
+import muit.backend.repository.ReportRepository;
 import muit.backend.service.MemberService;
+import muit.backend.service.ReportService;
 import muit.backend.service.postService.PostService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Tag(name = "게시글 공통")
 @RestController
@@ -23,6 +36,7 @@ public class CommonPostController {
 
     private final PostService postService;
     private final MemberService memberService;
+    private final ReportRepository reportRepository;
 
     @GetMapping("/likes/{postId}")
     @Operation(summary = "게시판 좋아요 API", description = "익명 게시판의 게시글 좋아요/좋아요 취소 API")
@@ -41,7 +55,7 @@ public class CommonPostController {
         return ApiResponse.onSuccess(postService.deletePost(postId, member));
     }
 
-    @PostMapping("/report/{postId}")
+    @PostMapping("/reports/{postId}")
     @Operation(summary = "게시글 신고 API", description = "게시글을 신고할 수 있는 API입니다.")
     public ApiResponse<ReportResponseDTO.ReportResultDTO> reportPost(@RequestHeader("Authorization") String accessToken,
                                                      @RequestBody ReportRequestDTO requestDTO,
@@ -50,6 +64,61 @@ public class CommonPostController {
         Member member = memberService.getMemberByToken(accessToken);
         return ApiResponse.onSuccess(postService.reportPost(postId, member,requestDTO));
 
+    }
+
+
+    public enum Type {
+        POST, COMMENT
+    }
+
+    @Tag(name="어드민이 신고 관리")
+    @GetMapping("/reports")
+    @Operation(summary = "신고 리스트 조회 API", description = "신고된 게시글 또는 댓글 목록을 조회하는 API")
+    @Parameters({
+            @Parameter( name = "page", description = "페이지를 정수로 입력"),
+            @Parameter(name = "size", description = "한 페이지 당 게시물 수"),
+    })
+    public ApiResponse<ReportResponseDTO.GeneralReportListDTO> getReportList( @RequestHeader("Authorization") String accessToken,
+                                                                       @RequestParam(name = "type", required = false) Type type,
+                                                                       @RequestParam(defaultValue = "0", name = "page") Integer page,
+                                                                       @RequestParam(defaultValue = "20", name = "size")Integer size)
+    {
+        Member member = memberService.getMemberByToken(accessToken);
+        if(member.getRole()!= Role.ADMIN){
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_ADMIN);
+        }
+
+        Page<Report> reports;
+        if(type==null){
+            reports= reportRepository.findAll(PageRequest.of(page, size));
+        }else if(type==Type.POST){
+            reports=reportRepository.findAllByReportObjectType(ReportObjectType.POST,PageRequest.of(page,size));
+        }else if(type==Type.COMMENT){
+            ReportObjectType[] types = {ReportObjectType.COMMENT,ReportObjectType.REPLY};
+            reports=reportRepository.findAllByReportObjectTypeIn(types,PageRequest.of(page,size));
+        }else{
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_OBJECT_TYPE);
+        }
+
+        List<ReportResponseDTO.GeneralReportDTO> reportDTOS = reports.stream().map((report)->{
+            return ReportResponseDTO.GeneralReportDTO.builder()
+                    .reportedObjectId(report.getReportedObjectId())
+                    .objectType(report.getReportObjectType())
+                    .id(report.getId())
+                    .memberId(member.getId())
+                    .content(report.getContent())
+                    .build();
+        }).toList();
+
+
+        return ApiResponse.onSuccess(ReportResponseDTO.GeneralReportListDTO.builder()
+                .reports(reportDTOS)
+                .listSize(reportDTOS.size())
+                .totalElements(reports.getTotalElements())
+                .isFirst(reports.isFirst())
+                .isLast(reports.isLast())
+                .totalPage(reports.getTotalPages())
+                .build());
     }
 
 }

--- a/src/main/java/muit/backend/converter/CommentConverter.java
+++ b/src/main/java/muit/backend/converter/CommentConverter.java
@@ -87,6 +87,7 @@ public class CommentConverter {
                     .isAnonymous(requestDTO.getIsAnonymous())
                     .anonymousIndex(index)
                     .content(requestDTO.getContent())
+                    .reportCount(0)
                     .member(member)
                     .build();
     }

--- a/src/main/java/muit/backend/converter/postConverter/PostConverter.java
+++ b/src/main/java/muit/backend/converter/postConverter/PostConverter.java
@@ -28,6 +28,7 @@ public class PostConverter {
                 .title(requestDTO.getTitle())
                 .content(requestDTO.getContent())
                 .commentCount(0)
+                .reportCount(0)
                 .postLikes(new ArrayList<>())
                 .images(imgList)
                 .build();

--- a/src/main/java/muit/backend/domain/entity/member/Comment.java
+++ b/src/main/java/muit/backend/domain/entity/member/Comment.java
@@ -40,12 +40,19 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
-    private List<Report> reportList = new ArrayList<>();
+    private Integer reportCount;
 
 
 
     public void deleteContent(String newContent) {
         this.content = newContent;
+    }
+
+    public void changeReportCount(Boolean isAdd){
+        if(isAdd){
+            this.reportCount++;
+        }else{
+            this.reportCount--;
+        }
     }
 }

--- a/src/main/java/muit/backend/domain/entity/member/Post.java
+++ b/src/main/java/muit/backend/domain/entity/member/Post.java
@@ -45,6 +45,8 @@ public class Post extends BaseEntity {
 
     private Integer commentCount;
 
+    private Integer reportCount;
+
     private Integer maxIndex;
 
     private Integer rating;
@@ -61,14 +63,8 @@ public class Post extends BaseEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> commentList = new ArrayList<>();
 
-//    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-//    private List<Comment> replyList = new ArrayList<>();
-
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostLikes> postLikes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Report> reportList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -98,6 +94,14 @@ public class Post extends BaseEntity {
             this.commentCount++;
         }else{
             this.commentCount--;
+        }
+    }
+
+    public void changeReportCount(Boolean isAdd){
+        if(isAdd){
+            this.reportCount++;
+        }else{
+            this.reportCount--;
         }
     }
 

--- a/src/main/java/muit/backend/domain/entity/member/Reply.java
+++ b/src/main/java/muit/backend/domain/entity/member/Reply.java
@@ -36,6 +36,13 @@ public class Reply extends BaseEntity {
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
-    @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL)
-    private List<Report> reportList = new ArrayList<>();
+    private Integer reportCount;
+
+    public void changeReportCount(Boolean isAdd){
+        if(isAdd){
+            this.reportCount++;
+        }else{
+            this.reportCount--;
+        }
+    }
 }

--- a/src/main/java/muit/backend/domain/entity/member/Report.java
+++ b/src/main/java/muit/backend/domain/entity/member/Report.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import muit.backend.domain.common.BaseEntity;
+import muit.backend.domain.enums.ReportObjectType;
 
 @Entity
 @Getter
@@ -24,17 +25,10 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
+    private Long reportedObjectId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
-    private Comment comment;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reply_id")
-    private Reply reply;
+    @Enumerated(EnumType.STRING)
+    private ReportObjectType reportObjectType;
 
 
 }

--- a/src/main/java/muit/backend/domain/enums/ReportObjectType.java
+++ b/src/main/java/muit/backend/domain/enums/ReportObjectType.java
@@ -1,0 +1,5 @@
+package muit.backend.domain.enums;
+
+public enum ReportObjectType {
+    POST,COMMENT, REPLY
+}

--- a/src/main/java/muit/backend/dto/reportDTO/ReportRequestDTO.java
+++ b/src/main/java/muit/backend/dto/reportDTO/ReportRequestDTO.java
@@ -5,5 +5,4 @@ import lombok.Getter;
 @Getter
 public class ReportRequestDTO {
     private String content;
-    private Long memberId;
 }

--- a/src/main/java/muit/backend/dto/reportDTO/ReportResponseDTO.java
+++ b/src/main/java/muit/backend/dto/reportDTO/ReportResponseDTO.java
@@ -4,8 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import muit.backend.domain.enums.ReportObjectType;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 public class ReportResponseDTO {
@@ -25,8 +27,22 @@ public class ReportResponseDTO {
     public static class GeneralReportDTO {
         private Long id;
         private String content;
-        private Long postId;
+        private Long reportedObjectId;
+        private ReportObjectType objectType;
         private LocalDateTime createdAt;
         private Long memberId;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GeneralReportListDTO {
+        private List<GeneralReportDTO> reports;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
     }
 }

--- a/src/main/java/muit/backend/repository/ReportRepository.java
+++ b/src/main/java/muit/backend/repository/ReportRepository.java
@@ -1,7 +1,16 @@
 package muit.backend.repository;
 
 import muit.backend.domain.entity.member.Report;
+import muit.backend.domain.enums.ReportObjectType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Integer> {
+
+    Page<Report> findAllByReportObjectType(ReportObjectType reportObjectType, PageRequest of);
+
+    Page<Report> findAllByReportObjectTypeIn(ReportObjectType[] types, PageRequest of);
 }
+

--- a/src/main/java/muit/backend/service/CommentServiceImpl.java
+++ b/src/main/java/muit/backend/service/CommentServiceImpl.java
@@ -106,10 +106,10 @@ public class CommentServiceImpl implements CommentService {
         Report report;
         if(commentType.equals("COMMENT")){
             Comment comment = commentRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
-            report = Report.builder().comment(comment).content(requestDTO.getContent()).build();
+            report = Report.builder().comment(comment).content(requestDTO.getContent()).member(member).build();
         }else if(commentType.equals("REPLY")){
             Reply reply = replyRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
-            report = Report.builder().reply(reply).content(requestDTO.getContent()).build();
+            report = Report.builder().reply(reply).content(requestDTO.getContent()).member(member).build();
         }else{
             throw new GeneralException(ErrorStatus.UNSUPPORTED_COMMENT_TYPE);
         }

--- a/src/main/java/muit/backend/service/CommentServiceImpl.java
+++ b/src/main/java/muit/backend/service/CommentServiceImpl.java
@@ -7,6 +7,7 @@ import muit.backend.apiPayLoad.code.status.ErrorStatus;
 import muit.backend.apiPayLoad.exception.GeneralException;
 import muit.backend.converter.CommentConverter;
 import muit.backend.domain.entity.member.*;
+import muit.backend.domain.enums.ReportObjectType;
 import muit.backend.dto.commentDTO.CommentReplyRequestDTO;
 import muit.backend.dto.commentDTO.CommentReplyResponseDTO;
 import muit.backend.dto.reportDTO.ReportRequestDTO;
@@ -101,22 +102,30 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
+    @Transactional
     public ReportResponseDTO.ReportResultDTO reportComment(String commentType, Long commentId, Member member, ReportRequestDTO requestDTO) {
 
         Report report;
         if(commentType.equals("COMMENT")){
+            //comment 검증과 DTO->Entity
             Comment comment = commentRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
-            report = Report.builder().comment(comment).content(requestDTO.getContent()).member(member).build();
+            report = Report.builder().reportedObjectId(comment.getId()).reportObjectType(ReportObjectType.COMMENT).content(requestDTO.getContent()).member(member).build();
+
+            report = reportRepository.save(report);
+            comment.changeReportCount(true);
         }else if(commentType.equals("REPLY")){
+            //Reply 검증과 DTO->Entity
             Reply reply = replyRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
-            report = Report.builder().reply(reply).content(requestDTO.getContent()).member(member).build();
+            report = Report.builder().reportedObjectId(reply.getId()).reportObjectType(ReportObjectType.REPLY).content(requestDTO.getContent()).member(member).build();
+
+            report = reportRepository.save(report);
+            reply.changeReportCount(true);
         }else{
             throw new GeneralException(ErrorStatus.UNSUPPORTED_COMMENT_TYPE);
         }
 
-        Report saved = reportRepository.save(report);
 
-        return ReportResponseDTO.ReportResultDTO.builder().id(saved.getId()).message("정상적으로 신고 처리 되었습니다.").build();
+        return ReportResponseDTO.ReportResultDTO.builder().id(report.getId()).message("정상적으로 신고 처리 되었습니다.").build();
     }
 
 }

--- a/src/main/java/muit/backend/service/ReportService.java
+++ b/src/main/java/muit/backend/service/ReportService.java
@@ -1,0 +1,7 @@
+package muit.backend.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ReportService {
+}

--- a/src/main/java/muit/backend/service/ReportServiceImpl.java
+++ b/src/main/java/muit/backend/service/ReportServiceImpl.java
@@ -1,0 +1,7 @@
+package muit.backend.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportServiceImpl {
+}

--- a/src/main/java/muit/backend/service/postService/PostServiceImpl.java
+++ b/src/main/java/muit/backend/service/postService/PostServiceImpl.java
@@ -194,6 +194,6 @@ public class PostServiceImpl implements PostService {
         Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
         Report report = Report.builder().content(requestDTO.getContent()).member(member).post(post).build();
         Report saved = reportRepository.save(report);
-        return ReportResponseDTO.ReportResultDTO.builder().id(saved.getId()).message("신고가 정상적으로 접수되었습니다.").build();
+        return ReportResponseDTO.ReportResultDTO.builder().id(saved.getId()).message("정상적으로 신고 처리 되었습니다.").build();
     }
 }

--- a/src/main/java/muit/backend/service/postService/PostServiceImpl.java
+++ b/src/main/java/muit/backend/service/postService/PostServiceImpl.java
@@ -9,6 +9,7 @@ import muit.backend.domain.entity.member.Post;
 import muit.backend.domain.entity.member.PostLikes;
 import muit.backend.domain.entity.member.Report;
 import muit.backend.domain.enums.PostType;
+import muit.backend.domain.enums.ReportObjectType;
 import muit.backend.dto.postDTO.PostRequestDTO;
 import muit.backend.dto.postDTO.PostResponseDTO;
 import muit.backend.dto.reportDTO.ReportRequestDTO;
@@ -190,10 +191,16 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional
     public ReportResponseDTO.ReportResultDTO reportPost(Long postId, Member member, ReportRequestDTO requestDTO) {
+        //post 유효성 검사
         Post post = postRepository.findById(postId).orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
-        Report report = Report.builder().content(requestDTO.getContent()).member(member).post(post).build();
+
+        //DTO->Entity
+        Report report = Report.builder().content(requestDTO.getContent()).member(member).reportedObjectId(post.getId()).reportObjectType(ReportObjectType.POST).build();
+
         Report saved = reportRepository.save(report);
+        post.changeReportCount(true);
         return ReportResponseDTO.ReportResultDTO.builder().id(saved.getId()).message("정상적으로 신고 처리 되었습니다.").build();
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- **report의 기능이 댓글(답글), 게시글로 확장됨에 따라 속성 컬럼을 수정합니다** : <br/> POST,COMMENT,REPLY와의 연관관계를 제거하고 reportedObjectId(게시글/댓글/답글의 id), ObjectType enum{POST,COMMENT,REPLY} 두가지 속성을 추가합니다.
- 어드민이 신고 내역을 확인하는 API 제작합니다.