### PR TITLE
[fix] comment and report

### DIFF
--- a/src/main/java/muit/backend/converter/postConverter/LostConverter.java
+++ b/src/main/java/muit/backend/converter/postConverter/LostConverter.java
@@ -25,6 +25,7 @@ public class LostConverter {
                 .content(requestDTO.getContent())
                 .images(imgList)
                 .commentCount(0)
+                .reportCount(0)
                 .location(requestDTO.getLocation())
                 .lostItem(requestDTO.getLostItem())
                 .lostDate(requestDTO.getLostDate())

--- a/src/main/java/muit/backend/converter/postConverter/ReviewConverter.java
+++ b/src/main/java/muit/backend/converter/postConverter/ReviewConverter.java
@@ -28,6 +28,7 @@ public class ReviewConverter {
                 .musical(musical)
                 .musicalName(musical.getName())
                 .commentCount(0)
+                .reportCount(0)
                 .rating(requestDTO.getRating())
                 .location(musical.getTheatre().getName())
                 .build();

--- a/src/main/java/muit/backend/service/CommentServiceImpl.java
+++ b/src/main/java/muit/backend/service/CommentServiceImpl.java
@@ -76,6 +76,9 @@ public class CommentServiceImpl implements CommentService {
 
         if(commentType.equals("COMMENT")){
             Comment comment = commentRepository.findById(commentId).orElseThrow(()->new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+            if(comment.getAnonymousIndex()==-2){
+                throw new GeneralException(ErrorStatus.COMMENT_NOT_FOUND);
+            }
             //작성자와 동일인인지 검사/또는 관리자인지
             if(comment.getMember()==member||comment.getMember().getRole()== Role.ADMIN){
                 if(!comment.getReplyList().isEmpty()){//대댓글 있으면 내용을 삭제된 댓글입니다 로


### PR DESCRIPTION
## 🔎 작업 내용

- comment 가 대댓글로 인해 삭제되지 않고 '삭제된 댓글입니다'로 대체될 경우 계속 삭제요청을 보낼 수 있는 것을 고칩니다
- reportCount를 일반 익명게시글 뿐 아니라 다른 게시글에서도 0으로 초기화해줍니다
