### PR TITLE
[fix] originalImgUrls - accept empty list

### DIFF
--- a/src/main/java/muit/backend/service/postService/PostServiceImpl.java
+++ b/src/main/java/muit/backend/service/postService/PostServiceImpl.java
@@ -167,8 +167,8 @@ public class PostServiceImpl implements PostService {
 
         //기존 이미지 url->UuidFile화
         List<UuidFile> dtoImgs = null;
-        if(requestDTO.getOriginalImgUrls()!=null&&!requestDTO.getOriginalImgUrls().isEmpty()){
-            requestDTO.getOriginalImgUrls().stream().map(file->
+        if(requestDTO.getOriginalImgUrls()!=null){
+            dtoImgs = requestDTO.getOriginalImgUrls().stream().map(file->
                     uuidFileService.getUuidFileByFileUrl(file).orElseThrow(()->new GeneralException(ErrorStatus.IMAGE_NOT_FOUND))).toList();
         }
 


### PR DESCRIPTION
## 🔎 작업 내용

- originalImgUrl 이 빈 배열로 올 시에 모든 이미지를 삭제합니다
